### PR TITLE
Fix possible strncat() overflow

### DIFF
--- a/src/tree.c
+++ b/src/tree.c
@@ -587,7 +587,7 @@ static void LoadChar( char *buf, int buf_len, uint16 phoneSeq[], int nPhoneSeq )
 	memset(buf, 0, buf_len);
 	for ( i = 0; i < nPhoneSeq; i++ ) {
 		GetCharFirst( &word, phoneSeq[ i ] );
-		strncat(buf, word.word, buf_len);
+		strncat(buf, word.word, buf_len - strlen(buf) - 1);
 	}
 	buf[ buf_len - 1 ] = '\0';
 }


### PR DESCRIPTION
strncat(dst, src, n) use at most n bytes from src.

man strncat say:

If src contains n or more bytes, strncat() writes n+1 bytes to dest (n from src plus the terminating null byte). Therefore, the size of dest must be at least strlen(dest)+n+1.

So we need to have "buf_len - strlen(buf) - 1"
