### PR TITLE
Use PgUp/PgDn to turn pages of candidates

### DIFF
--- a/src/chewingio.c
+++ b/src/chewingio.c
@@ -1070,6 +1070,13 @@ CHEWING_API int chewing_handle_PageUp( ChewingContext *ctx )
 	else if ( ! pgdata->bSelect ) {
 		pgdata->chiSymbolCursor = pgdata->chiSymbolBufLen;
 	}
+	else if ( pgdata->bSelect ) {
+		assert( pgdata->choiceInfo.nPage > 0 );
+		if ( pgdata->choiceInfo.pageNo > 0 )
+			pgdata->choiceInfo.pageNo--;
+		else
+			pgdata->choiceInfo.pageNo = pgdata->choiceInfo.nPage - 1;
+	}
 	MakeOutputWithRtn( pgo, pgdata, keystrokeRtn );
 	return 0;
 }
@@ -1087,6 +1094,12 @@ CHEWING_API int chewing_handle_PageDown( ChewingContext *ctx )
 	}
 	else if ( ! pgdata->bSelect ) {
 		pgdata->chiSymbolCursor = pgdata->chiSymbolBufLen;
+	}
+	else if ( pgdata->bSelect ) {
+		if ( pgdata->choiceInfo.pageNo < pgdata->choiceInfo.nPage - 1)
+			pgdata->choiceInfo.pageNo++;
+		else
+			pgdata->choiceInfo.pageNo = 0;
 	}
 	MakeOutputWithRtn( pgo, pgdata, keystrokeRtn );
 	return 0;

--- a/test/test-bopomofo.c
+++ b/test/test-bopomofo.c
@@ -783,7 +783,7 @@ void test_End()
 	chewing_delete( ctx );
 }
 
-void test_PageUp()
+void test_PageUp_not_entering_chewing()
 {
 	ChewingContext *ctx;
 	int cursor;
@@ -803,7 +803,32 @@ void test_PageUp()
 	chewing_delete( ctx );
 }
 
-void test_PageDown()
+void test_PageUp_in_select()
+{
+	ChewingContext *ctx;
+
+	ctx = chewing_new();
+	start_testcase( ctx, fd );
+
+	chewing_set_candPerPage( ctx, 10 );
+
+	type_keystroke_by_string( ctx, "hk4<D>" );
+	ok( chewing_cand_TotalPage( ctx ) == 3, "total page shall be 3" );
+	ok( chewing_cand_CurrentPage( ctx ) == 0, "current page shall be 0" );
+
+	type_keystroke_by_string( ctx, "<PU>" );
+	ok( chewing_cand_CurrentPage( ctx ) == 2, "current page shall be 2" );
+
+	chewing_delete( ctx );
+}
+
+void test_PageUp()
+{
+	test_PageUp_not_entering_chewing();
+	test_PageUp_in_select();
+}
+
+void test_PageDown_not_entering_chewing()
 {
 	ChewingContext *ctx;
 	int cursor;
@@ -821,6 +846,34 @@ void test_PageDown()
 	ok( cursor == 2, "cursor `%d' shall be 2", cursor );
 
 	chewing_delete( ctx );
+}
+
+void test_PageDown_in_select()
+{
+	ChewingContext *ctx;
+
+	ctx = chewing_new();
+	start_testcase( ctx, fd );
+
+	chewing_set_candPerPage( ctx, 10 );
+
+	type_keystroke_by_string( ctx, "hk4<D>" );
+	ok( chewing_cand_TotalPage( ctx ) == 3, "total page shall be 3" );
+	ok( chewing_cand_CurrentPage( ctx ) == 0, "current page shall be 0" );
+
+	type_keystroke_by_string( ctx, "<PD>" );
+	ok( chewing_cand_CurrentPage( ctx ) == 1, "current page shall be 1" );
+
+	type_keystroke_by_string( ctx, "<PD><PD>" ); /* rollover */
+	ok( chewing_cand_CurrentPage( ctx ) == 0, "current page shall be 0" );
+
+	chewing_delete( ctx );
+}
+
+void test_PageDown()
+{
+	test_PageDown_not_entering_chewing();
+	test_PageDown_in_select();
 }
 
 void test_ShiftSpace()


### PR DESCRIPTION
This is a common feature provided by many Bopomofo-IMs as well as the Win32-chewing.

Codes are copied from chewing_handle_left/right.
