### PR TITLE
Reopen candidate list for symbols with down key

### DIFF
--- a/src/chewingio.c
+++ b/src/chewingio.c
@@ -124,8 +124,18 @@ static void chooseCandidate( ChewingContext *ctx, int toSelect, int key_buf_curs
 		}
 	} else if ( pgdata->symbolKeyBuf[ key_buf_cursor ] ) {
 		/* Open Symbol Choice List */
-		if ( pgdata->choiceInfo.isSymbol == WORD_CHOICE )
+		if ( pgdata->choiceInfo.isSymbol == WORD_CHOICE ) {
 			OpenSymbolChoice( pgdata );
+		}
+		/**
+		 * If these's only one candidate list available, ChoiceFirstAvail
+		 * will re-open the list, namely turn back to the firt page. 
+		 * However, it doesn't work for symbols, therefore we 
+		 * set the page number to 0 directly.
+		 */
+		else if ( pgdata->bSelect ) {
+			pgdata->choiceInfo.pageNo = 0;
+		}
 	}
 }
 

--- a/test/test-bopomofo.c
+++ b/test/test-bopomofo.c
@@ -630,6 +630,22 @@ void test_Down_open_candidate_window()
 	chewing_delete( ctx );
 }
 
+void test_Down_reopen_symbol_candidate()
+{
+	ChewingContext *ctx;
+
+	ctx = chewing_new();
+	start_testcase( ctx, fd );
+
+	type_keystroke_by_string( ctx, "_<D><R>");
+	ok( chewing_cand_CurrentPage( ctx ) == 1, "current page shall be 1" );
+
+	type_keystroke_by_string( ctx, "<D>");
+	ok( chewing_cand_CurrentPage( ctx ) == 0, "current page shall be 0" );
+
+	chewing_delete( ctx );
+}
+
 void test_Down_not_entering_chewing()
 {
 	ChewingContext *ctx;


### PR DESCRIPTION
If these's only one candidate list available, down key
will use ChoiceFirstAvail to re-open the list, and turn
back to the first page. However, it doesn't work for
symbols, therefore we set the page number to 0 directly.

This should fix #127.
