### PR TITLE
Fix unexpected candidate disorder for '1'.

### DIFF
--- a/test/test-symbol.c
+++ b/test/test-symbol.c
@@ -395,6 +395,28 @@ void test_symbol()
     test_symbol_count();
 }
 
+void test_nocand_symbol()
+{
+    ChewingContext *ctx;
+
+    ctx = chewing_new();
+    start_testcase(ctx, fd);
+
+    chewing_set_candPerPage(ctx, 10);
+    chewing_set_maxChiSymbolLen(ctx, 16);
+
+    type_keystroke_by_string(ctx, "`<R>20");
+    ok_preedit_buffer(ctx, "\xE2\x96\x88"); /* █ */
+
+    type_keystroke_by_string(ctx, "<D>");
+    ok_candidate(ctx, CAND, ARRAY_SIZE(CAND));
+
+    type_keystroke_by_string(ctx, "1<E>"); /* select … */
+    ok_commit_buffer(ctx, "\xE2\x80\xA6");
+
+    chewing_delete(ctx);
+}
+
 int main(int argc, char *argv[])
 {
     char *logname;
@@ -412,6 +434,7 @@ int main(int argc, char *argv[])
 
     test_type_symbol();
     test_symbol();
+    test_nocand_symbol();
 
     fclose(fd);
 


### PR DESCRIPTION
This is related to 64b45c5b7a43af88640fe51964020801bec6531c.
Originally, all symbols that do not have alternative symbol candidates would be assigned a '1' for `symbolKeyBuf`. And when trying to open a candidate window for these symbols, `HaninSymbolInput` would be called. However, `SymbolChoice` does not handle this situation correctly and causes some problems.  That is, a new symbol would be inserted without changing the original symbol.

The previous commit hides this problem, but when the candidate symbol is '1', this problem resurfaces.

This should close #44.
