### PR TITLE
Fix inconsistent CHEWING_DATADIR definition

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -4,7 +4,7 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir)/include \
 	-I$(top_srcdir)/include/internal \
 	-I$(top_srcdir)/src/porting_layer/include \
-	-DCHEWING_DATADIR=\"$(datadir)/chewing\" \
+	-DCHEWING_DATADIR=\"$(datadir)/libchewing\" \
 	$(USERPHRASE_CPPFLAGS) \
 	$(DEFAULT_CPPFLAGS) \
 	$(NULL)

--- a/src/porting_layer/src/Makefile.am
+++ b/src/porting_layer/src/Makefile.am
@@ -1,7 +1,7 @@
 MAINTAINERCLEANFILES = Makefile.in
 
 AM_CPPFLAGS = \
-	-DCHEWING_DATADIR=\"@datadir@\" \
+	-DCHEWING_DATADIR=\"$(datadir)/libchewing\" \
 	-I$(top_srcdir)/include \
 	-I$(top_srcdir)/include/internal \
 	-I$(top_srcdir)/src/porting_layer/include \

--- a/src/porting_layer/src/plat_path.c
+++ b/src/porting_layer/src/plat_path.c
@@ -36,10 +36,10 @@ int get_search_path(char *path, size_t path_len)
     } else {
         home = getenv("HOME");
         if (home) {
-            snprintf(path, path_len, "%s/.chewing" SEARCH_PATH_SEP CHEWING_DATADIR "/libchewing", home);
+            snprintf(path, path_len, "%s/.chewing" SEARCH_PATH_SEP CHEWING_DATADIR, home);
         } else {
             // No HOME ?
-            strncpy(path, SEARCH_PATH_SEP CHEWING_DATADIR "/libchewing", path_len);
+            strncpy(path, SEARCH_PATH_SEP CHEWING_DATADIR, path_len);
         }
     }
 


### PR DESCRIPTION
This fixes the problem that causes chewing_new to return NULL when building
with CMake. Close #178.