### PR TITLE
Fix ChewingKillChar which is disabling OpenSymbolChoice

### DIFF
--- a/src/chewingutil.c
+++ b/src/chewingutil.c
@@ -1004,6 +1004,9 @@ int ChewingKillChar(ChewingData *pgdata, int chiSymbolCursorToKill, int minus)
     }
     pgdata->symbolKeyBuf[chiSymbolCursorToKill] = 0;
     assert(pgdata->chiSymbolBufLen - chiSymbolCursorToKill);
+    memmove(&pgdata->symbolKeyBuf[chiSymbolCursorToKill],
+            &pgdata->symbolKeyBuf[chiSymbolCursorToKill + 1],
+            sizeof(pgdata->symbolKeyBuf[0]) * (pgdata->chiSymbolBufLen - chiSymbolCursorToKill));
     memmove(&pgdata->preeditBuf[chiSymbolCursorToKill],
             &pgdata->preeditBuf[chiSymbolCursorToKill + 1],
             sizeof(pgdata->preeditBuf[0]) * (pgdata->chiSymbolBufLen - chiSymbolCursorToKill));

--- a/test/test-bopomofo.c
+++ b/test/test-bopomofo.c
@@ -743,10 +743,35 @@ void test_Down_not_entering_chewing()
     chewing_delete(ctx);
 }
 
+void test_Down_open_candidate_window_after_deleting_symbol()
+{
+    ChewingContext *ctx;
+    int ret;
+
+    ctx = chewing_new();
+    start_testcase(ctx, fd);
+
+    type_keystroke_by_string(ctx, "<<>hk4g4<<>" /* ，測試， */);
+    ret = chewing_cand_TotalChoice(ctx);
+    ok(ret == 0, "chewing_cand_TotalChoice() returns `%d' shall be `%d'", ret, 0);
+
+    type_keystroke_by_string(ctx, "<H><DC><EN><D>" /* Home Delete End Down */);
+    ret = chewing_cand_TotalChoice(ctx);
+    ok(ret > 0, "chewing_cand_TotalChoice() returns `%d' shall be greater than `%d'", ret, 0);
+
+    type_keystroke_by_string(ctx, "2");
+    ret = chewing_cand_TotalChoice(ctx);
+    ok(ret == 0, "chewing_cand_TotalChoice() returns `%d' shall be `%d'", ret, 0);
+    ok_preedit_buffer(ctx, "\xE6\xB8\xAC\xE8\xA9\xA6\xE2\x86\x90" /* 測試← */ );
+
+    chewing_delete(ctx);
+}
+
 void test_Down()
 {
     test_Down_open_candidate_window();
     test_Down_not_entering_chewing();
+    test_Down_open_candidate_window_after_deleting_symbol();
 }
 
 void test_Tab_insert_breakpoint_between_word()


### PR DESCRIPTION
This patch fixes issue #160.
The bug is caused by an out-of-date `pgdata->symbolKeyBuf` in `ChewingKillChar`. We simply remove the symbol key which corresponds to `chiSymbolCursorToKill`.