### PR TITLE
Fix #170 (ㄅ cannot overwrite ㄆ in HSU and ET26)

### DIFF
--- a/src/bopomofo.c
+++ b/src/bopomofo.c
@@ -230,6 +230,13 @@ static int HsuPhoInput(ChewingData *pgdata, int key)
             if (!inx)
                 continue;       /* if inx == 0, next type */
             else if (type == 0) {
+                /**
+                 * Hsu maps multiple bopomofo into one single key.
+                 * Therefore, if a consonant or a medial already exists
+                 * in buffer, and the user presses a key with consonant
+                 * and rhyme, libchewing should consider that the user
+                 * wants to input the rhyme.
+                 */
                 if ((inx == 3 || (7 <= inx && inx <= 11) || inx == 20)
                     && (pBopomofo->pho_inx[0] || pBopomofo->pho_inx[1])) {
                     /* if inx !=0 */

--- a/src/bopomofo.c
+++ b/src/bopomofo.c
@@ -329,7 +329,14 @@ static int ET26PhoInput(ChewingData *pgdata, int key)
             if (!inx)
                 continue;       /* if inx == 0, next type */
             else if (type == 0) {
-                if (pBopomofo->pho_inx[0] || pBopomofo->pho_inx[1]) {
+                 /**
+                  * Same as Hsu: If a consonant or a medial already exists
+                  * in buffer, and the user presses a key with consonant
+                  * and rhyme, libchewing should consider that the user
+                  * wants to input the rhyme.
+                  */
+                if ((inx == 2 || inx == 3 || inx == 11 || inx == 19 || inx == 20 ||
+                    (6 <= inx && inx <= 8)) && (pBopomofo->pho_inx[0] || pBopomofo->pho_inx[1])) {
                     /* if inx !=0 */
                     searchTimes = 2;    /* possible infinite loop here */
                 } else

--- a/src/bopomofo.c
+++ b/src/bopomofo.c
@@ -230,7 +230,8 @@ static int HsuPhoInput(ChewingData *pgdata, int key)
             if (!inx)
                 continue;       /* if inx == 0, next type */
             else if (type == 0) {
-                if (pBopomofo->pho_inx[0] || pBopomofo->pho_inx[1]) {
+                if ((inx == 3 || (7 <= inx && inx <= 11) || inx == 20)
+                    && (pBopomofo->pho_inx[0] || pBopomofo->pho_inx[1])) {
                     /* if inx !=0 */
                     searchTimes = 2;    /* possible infinite loop here */
                 } else

--- a/test/test-keyboard.c
+++ b/test/test-keyboard.c
@@ -132,8 +132,7 @@ void test_hsu_po_to_bo()
     ok_bopomofo_buffer(ctx, "\xE3\x84\x86" /* ㄆ */ );
 
     type_keystroke_by_string(ctx, "b");
-    // FIXME: ㄅ shall overwrite ㄆ
-    //ok_bopomofo_buffer(ctx, "\xE3\x84\x85" /* ㄅ */ );
+    ok_bopomofo_buffer(ctx, "\xE3\x84\x85" /* ㄅ */ );
 
     chewing_delete(ctx);
 }

--- a/test/test-keyboard.c
+++ b/test/test-keyboard.c
@@ -142,6 +142,30 @@ void test_hsu()
     test_hsu_po_to_bo();
 }
 
+void test_et26_po_to_bo()
+{
+    // https://github.com/chewing/libchewing/issues/170
+    ChewingContext *ctx;
+
+    ctx = chewing_new();
+    start_testcase(ctx, fd);
+
+    chewing_set_KBType(ctx, chewing_KBStr2Num("KB_ET26"));
+
+    type_keystroke_by_string(ctx, "p");
+    ok_bopomofo_buffer(ctx, "\xE3\x84\x86" /* ㄆ */ );
+
+    type_keystroke_by_string(ctx, "b");
+    ok_bopomofo_buffer(ctx, "\xE3\x84\x85" /* ㄅ */ );
+
+    chewing_delete(ctx);
+}
+
+void test_et26()
+{
+    test_et26_po_to_bo();
+}
+
 int main(int argc, char *argv[])
 {
     char *logname;
@@ -162,6 +186,7 @@ int main(int argc, char *argv[])
     test_enumerate_keyboard_type();
 
     test_hsu();
+    test_et26();
 
     fclose(fd);
 


### PR DESCRIPTION
Because Hsu and ET26 map multiple bopomofo 
into one single key, therefore, if a consonant or 
a medial already exists in buffer, and the user 
presses a key with consonant and rhyme, libchewing 
should consider that the user wants to input the rhyme.