### PR TITLE
Make the python binding of libchewing support Windows dll files.

### DIFF
--- a/contrib/python/chewing.py
+++ b/contrib/python/chewing.py
@@ -1,8 +1,18 @@
 from ctypes import *
 from functools import partial
+import sys
 
+_libchewing = None
+if sys.platform == "win32": # Windows
+    import os.path
+    # find in current dir first
+    dll_path = os.path.join(os.path.dirname(__file__), "chewing.dll")
+    if not os.path.exists(dll_path):
+        dll_path = "chewing.dll" # search in system path
+    _libchewing = CDLL(dll_path)
+else: # UNIX-like systems
+    _libchewing = CDLL('libchewing.so.3')
 
-_libchewing = CDLL('libchewing.so.3')
 _libchewing.chewing_commit_String.restype = c_char_p
 _libchewing.chewing_buffer_String.restype = c_char_p
 _libchewing.chewing_cand_String.restype = c_char_p


### PR DESCRIPTION
Add platform check and if we're in Windows, load *.dll instead of *.so.
The current directory containing the python module is searched first.