### PR TITLE
Add Carpalx keyboard layout support

### DIFF
--- a/doc/libchewing.texi
+++ b/doc/libchewing.texi
@@ -471,6 +471,7 @@ The string @var{str} might be one of the following layouts:
 @item @code{KB_HANYU_PINYIN}
 @item @code{KB_THL_PINYIN}
 @item @code{KB_MPS2_PINYIN}
+@item @code{KB_CARPALX}
 @end itemize
 
 See also the @code{chewing_kbtype_*} enumeration functions.

--- a/include/internal/bopomofo-private.h
+++ b/include/internal/bopomofo-private.h
@@ -40,6 +40,7 @@ enum {
     KB_HANYU_PINYIN,
     KB_THL_PINYIN,
     KB_MPS2_PINYIN,
+    KB_CARPALX,
     KB_TYPE_NUM
 };
 

--- a/include/internal/chewing-private.h
+++ b/include/internal/chewing-private.h
@@ -86,6 +86,7 @@ typedef enum KBTYPE {
     KBTYPE_HANYU_PINYIN,
     KBTYPE_LUOMA_PINYIN,
     KBTYPE_MSP2,            /* Mandarin Phonetic Symbols II */
+    KBTYPE_CARPALX,
     KBTYPE_COUNT
 } KBTYPE;
 

--- a/src/chewingio.c
+++ b/src/chewingio.c
@@ -61,7 +61,8 @@ const char *const kb_type_str[] = {
     "KB_DACHEN_CP26",
     "KB_HANYU_PINYIN",
     "KB_THL_PINYIN",
-    "KB_MPS2_PINYIN"
+    "KB_MPS2_PINYIN",
+    "KB_CARPALX"
 };
 
 const char *const DICT_FILES[] = {

--- a/src/common/key2pho.c
+++ b/src/common/key2pho.c
@@ -82,6 +82,7 @@ static const char *const key_str[KBTYPE_COUNT] = {
     "1qaz2wsxedcrfv5tgbyhnujm8ik,9ol.0p;/-7634",        /* Hanyu Pinyin */
     "1qaz2wsxedcrfv5tgbyhnujm8ik,9ol.0p;/-7634",        /* Luoma Pinyin */
     "1qaz2wsxedcrfv5tgbyhnujm8ik,9ol.0p;/-7634",        /* secondary Bopomofo Pinyin */
+    "1qdz2gsxmtclnv5wrjyikfap8ue,9bo.0;h/-7634",        /* Carpalx */
 };
 
 /*

--- a/test/test-keyboard.c
+++ b/test/test-keyboard.c
@@ -32,6 +32,7 @@ static const char *const KEYBOARD_STRING[] = {
     "KB_HANYU_PINYIN",
     "KB_THL_PINYIN",
     "KB_MPS2_PINYIN",
+    "KB_CARPALX",
 };
 
 static const int KEYBOARD_DEFAULT_TYPE = 0;


### PR DESCRIPTION
The Carpalx keyboard layout was recently added to xkeyboard-config and kbd.

[xkeyboard-config](https://bugs.freedesktop.org/show_bug.cgi?id=94723)
[kbd](http://git.altlinux.org/people/legion/packages/kbd.git?p=kbd.git;a=commit;h=9ae1585479ab2a68c030790320ca45892cb6ea27)

It would be nice to not have to use a locally-patched version of libchewing to be able to type in Chinese.

Thanks,