### PR TITLE
用 CMake 編出來的 libchewing 又沒辦法執行了 ......

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -362,7 +362,7 @@ add_library(chewing OBJECT
     ${SRC_DIR}/bopomofo.c
 )
 set_target_properties(chewing PROPERTIES
-    COMPILE_DEFINITIONS "CHEWING_DATADIR=\"${CMAKE_INSTALL_DATADIR}/libchewing\""
+    COMPILE_DEFINITIONS "CHEWING_DATADIR=\"${CMAKE_INSTALL_FULL_DATADIR}/libchewing\""
 )
 
 if (WITH_SQLITE3)


### PR DESCRIPTION
`"CHEWING_DATADIR=\"${CMAKE_INSTALL_DATADIR}/libchewing\""`，但是 `CMAKE_INSTALL_DATADIR` 是相對路徑，造成 `chewing_new` 的時候失敗，找不到檔案。