### PR TITLE
Import 15735 phrases from McBopomofo project

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,9 @@ Except the following source code:
 * cmake/FindCurses.cmake is modified from CMake source, which is licensed under
    BSD 3-Clause.
 
+* some phrases in data/tsi.src are imported from McBopomofo(小麥輸入法) project,
+   which are MIT licensed.
+
 All source code are licensed under GNU LGPL v2.1 (Lesser General Public License
 v2.1). See "COPYING" for details.
 


### PR DESCRIPTION
McBopomofo(小麥輸入法)[1] is under MIT licensed, which means there won't be conflicts about the license issue with LGPL.

The phrases use `0` as default priority, they are sorted in `tsi.src`, and tuned a little bit, since ...
- there are some obviously spelled wrong phrases (about a hundred), since McBopomofo doesn't check phone and bopomofo like libchewing, so that I need to manually fix them all ...  and sent PR(s) to upstream to fix them (https://github.com/OpenVanilla/McBopomofo/pull/101).
- there are also issues about the pronounce of the words, like libchewing doesn't use `ㄇㄛ˙` as the pronounce for `麼`, and `ㄉㄨㄥˋ` for `丼`, for these cases, I'll remove them.
- there are some Japanese words like `栃`, for these cases, I'll remove them.

I also added the MIT license info in `README.md`.

For the detail about how they get their phrases, please refer to "小麥注音詞條資料主要來源": 
https://mcbopomofo.openvanilla.org/textpool.html

[1]: http://mcbopomofo.openvanilla.org/ / https://github.com/OpenVanilla/McBopomofo
## 

cc @lucienchlin @robert501128 @hwhung0111 #210
