### PR TITLE
Fix #235: Unable to input some Bopomofos with ET26 layout

### DIFF
--- a/src/choice.c
+++ b/src/choice.c
@@ -224,48 +224,100 @@ static void SetChoiceInfo(ChewingData *pgdata)
         if (pgdata->bopomofoData.kbtype == KB_HSU || pgdata->bopomofoData.kbtype == KB_DVORAK_HSU) {
             switch (phoneSeq[cursor]) {
             case 0x2800:       /* 'ㄘ' */
-                ChoiceInfoAppendChi(pgdata, pci, 0x30); /* 'ㄟ' */
+                ChoiceInfoAppendChi(pgdata, pci, 0x30);     /* 'ㄟ' */
                 break;
             case 0x80:         /* 'ㄧ' */
-                ChoiceInfoAppendChi(pgdata, pci, 0x20); /* 'ㄝ' */
+                ChoiceInfoAppendChi(pgdata, pci, 0x20);     /* 'ㄝ' */
                 break;
             case 0x2A00:       /* 'ㄙ' */
-                ChoiceInfoAppendChi(pgdata, pci, 0x1);  /* '˙' */
+                ChoiceInfoAppendChi(pgdata, pci, 0x1);      /* '˙' */
                 break;
             case 0xA00:        /* 'ㄉ' */
-                ChoiceInfoAppendChi(pgdata, pci, 0x2);  /* 'ˊ' */
+                ChoiceInfoAppendChi(pgdata, pci, 0x2);      /* 'ˊ' */
                 break;
             case 0x800:        /* 'ㄈ' */
-                ChoiceInfoAppendChi(pgdata, pci, 0x3);  /* 'ˇ' */
+                ChoiceInfoAppendChi(pgdata, pci, 0x3);      /* 'ˇ' */
                 break;
             case 0x18:         /* 'ㄜ' */
-                ChoiceInfoAppendChi(pgdata, pci, 0x1200);       /* 'ㄍ' */
+                ChoiceInfoAppendChi(pgdata, pci, 0x1200);   /* 'ㄍ' */
                 break;
             case 0x10:         /* 'ㄛ' */
-                ChoiceInfoAppendChi(pgdata, pci, 0x1600);       /* 'ㄏ' */
+                ChoiceInfoAppendChi(pgdata, pci, 0x1600);   /* 'ㄏ' */
                 break;
             case 0x1E00:       /* 'ㄓ' */
-                ChoiceInfoAppendChi(pgdata, pci, 0x1800);       /* 'ㄐ' */
-                ChoiceInfoAppendChi(pgdata, pci, 0x4);  /* 'ˋ' */
+                ChoiceInfoAppendChi(pgdata, pci, 0x1800);   /* 'ㄐ' */
+                ChoiceInfoAppendChi(pgdata, pci, 0x4);      /* 'ˋ' */
                 break;
             case 0x58:         /* 'ㄤ' */
-                ChoiceInfoAppendChi(pgdata, pci, 0x1400);       /* 'ㄎ' */
+                ChoiceInfoAppendChi(pgdata, pci, 0x1400);   /* 'ㄎ' */
                 break;
             case 0x68:         /* 'ㄦ' */
-                ChoiceInfoAppendChi(pgdata, pci, 0x1000);       /* 'ㄌ' */
-                ChoiceInfoAppendChi(pgdata, pci, 0x60); /* 'ㄥ' */
+                ChoiceInfoAppendChi(pgdata, pci, 0x1000);   /* 'ㄌ' */
+                ChoiceInfoAppendChi(pgdata, pci, 0x60);     /* 'ㄥ' */
                 break;
             case 0x2200:       /* 'ㄕ' */
-                ChoiceInfoAppendChi(pgdata, pci, 0x1C00);       /* 'ㄒ' */
+                ChoiceInfoAppendChi(pgdata, pci, 0x1C00);   /* 'ㄒ' */
                 break;
             case 0x2000:       /* 'ㄔ' */
-                ChoiceInfoAppendChi(pgdata, pci, 0x1A00);       /* 'ㄑ' */
+                ChoiceInfoAppendChi(pgdata, pci, 0x1A00);   /* 'ㄑ' */
                 break;
             case 0x50:         /* 'ㄣ' */
-                ChoiceInfoAppendChi(pgdata, pci, 0xE00);        /* 'ㄋ' */
+                ChoiceInfoAppendChi(pgdata, pci, 0xE00);    /* 'ㄋ' */
                 break;
             case 0x48:         /* 'ㄢ' */
-                ChoiceInfoAppendChi(pgdata, pci, 0x600);        /* 'ㄇ' */
+                ChoiceInfoAppendChi(pgdata, pci, 0x600);    /* 'ㄇ' */
+                break;
+            default:
+                break;
+            }
+        }
+
+        if (pgdata->bopomofoData.kbtype == KB_ET26) {
+            switch (phoneSeq[cursor]) {
+            case 0x40:      /* 'ㄡ' */
+                ChoiceInfoAppendChi(pgdata, pci, 0x400);    /* 'ㄆ' */
+                break;
+            case 0x58:      /* 'ㄤ' */
+                ChoiceInfoAppendChi(pgdata, pci, 0xC00);    /* 'ㄊ' */
+                break;
+            case 0x2800:    /* 'ㄘ' */
+                ChoiceInfoAppendChi(pgdata, pci, 0x20);     /* 'ㄝ' */
+                break;
+            case 0x2600:    /* 'ㄗ' */
+                ChoiceInfoAppendChi(pgdata, pci, 0x30);     /* 'ㄟ' */
+                break;
+            case 0x1E00:    /* 'ㄓ' */
+                ChoiceInfoAppendChi(pgdata, pci, 0x1800);   /* 'ㄐ' */
+                break;
+            case 0x68:      /* 'ㄦ' */
+                ChoiceInfoAppendChi(pgdata, pci, 0x1600);   /* 'ㄏ' */
+                break;
+            case 0x60:      /* 'ㄥ' */
+                ChoiceInfoAppendChi(pgdata, pci, 0x1000);   /* 'ㄌ' */
+                break;
+            case 0x2200:    /* 'ㄕ' */
+                ChoiceInfoAppendChi(pgdata, pci, 0x1C00);   /* 'ㄒ' */
+                break;
+            case 0x1200:    /* 'ㄍ' */
+                ChoiceInfoAppendChi(pgdata, pci, 0x1A00);   /* 'ㄑ' */
+                break;
+            case 0x50:      /* 'ㄣ' */
+                ChoiceInfoAppendChi(pgdata, pci, 0xE00);    /* 'ㄋ' */
+                break;
+            case 0x48:      /* 'ㄢ' */
+                ChoiceInfoAppendChi(pgdata, pci, 0x600);    /* 'ㄇ' */
+                break;
+            case 0xA00:     /* 'ㄉ' */
+                ChoiceInfoAppendChi(pgdata, pci, 0x1);      /* '˙' */
+                break;
+            case 0x800:     /* 'ㄈ' */
+                ChoiceInfoAppendChi(pgdata, pci, 0x2);      /* 'ˊ' */
+                break;
+            case 0x2400:    /* 'ㄖ' */
+                ChoiceInfoAppendChi(pgdata, pci, 0x3);      /* 'ˇ' */
+                break;
+            case 0x1400:    /* 'ㄎ' */
+                ChoiceInfoAppendChi(pgdata, pci, 0x4);      /* 'ˋ' */
                 break;
             default:
                 break;

--- a/test/test-bopomofo.c
+++ b/test/test-bopomofo.c
@@ -1467,6 +1467,56 @@ void test_KB_HSU()
     chewing_delete(ctx);
 }
 
+void test_KB_HSU_choice_append()
+{
+    const TestData CHOICE_INFO_APPEND[] = {
+        {"e " /* ㄧ */, "\xE3\x84\x9D" /* ㄝ */ },
+        {"g " /* ㄜ */, "\xE3\x84\x8D" /* ㄍ */ },
+        {"h " /* ㄛ */, "\xE3\x84\x8F" /* ㄏ */ },
+        {"k " /* ㄤ */, "\xE3\x84\x8E" /* ㄎ */ },
+        {"c " /* ㄕ */, "\xE3\x84\x92" /* ㄒ */ },
+        {"n " /* ㄣ */, "\xE3\x84\x8B" /* ㄋ */ },
+        {"m " /* ㄢ */, "\xE3\x84\x87" /* ㄇ */ },
+        {"s " /* ㄙ */, "\xCB\x99" /* ˙ */ },
+        {"d " /* ㄉ */, "\xCB\x8A" /* ˊ */ },
+        {"f " /* ㄈ */, "\xCB\x87" /* ˇ */ },
+        {"j " /* ㄓ */, "\xCB\x8B" /* ˋ */ },
+        {"l " /* ㄦ */, "\xE3\x84\xA5" /* ㄥ */ },
+        {"a " /* ㄘ */, "\xE3\x84\x9F" /* ㄟ */ },
+        {"j " /* ㄓ */, "\xE3\x84\x90" /* ㄐ */ },
+        {"l " /* ㄦ */, "\xE3\x84\x8C" /* ㄌ */ },
+    };
+    size_t i;
+    ChewingContext *ctx;
+    int totalChoice;
+    const char *cand;
+
+    ctx = chewing_new();
+    start_testcase(ctx, fd);
+    chewing_set_KBType(ctx, KB_HSU);
+
+    for (i = 0; i < ARRAY_SIZE(CHOICE_INFO_APPEND); ++i) {
+
+        type_keystroke_by_string(ctx, CHOICE_INFO_APPEND[i].token);
+
+        chewing_cand_open(ctx);
+        totalChoice = chewing_cand_TotalChoice(ctx);
+
+        if (i == 14) {
+            cand = chewing_cand_string_by_index_static(ctx, totalChoice - 3);
+        } else if (i == 13 || i == 12) {
+            cand = chewing_cand_string_by_index_static(ctx, totalChoice - 2);
+        } else {
+            cand = chewing_cand_string_by_index_static(ctx, totalChoice - 1);
+        }
+
+        ok(strcmp(cand, CHOICE_INFO_APPEND[i].expected) == 0, "returned candidate is `%s' shall be `%s'", cand, CHOICE_INFO_APPEND[i].expected);
+
+        chewing_cand_close(ctx);
+        chewing_clean_preedit_buf(ctx);
+    }
+    chewing_delete(ctx);
+}
 
 void test_KB_ET26()
 {
@@ -1534,6 +1584,55 @@ void test_KB_ET26()
     chewing_delete(ctx);
 }
 
+void test_KB_ET26_choice_append()
+{
+    const TestData CHOICE_INFO_APPEND[] = {
+        { "p " /* ㄡ */, "\xE3\x84\x86" /* ㄆ */ },
+        { "t " /* ㄤ */, "\xE3\x84\x8A" /* ㄊ */ },
+        { "w " /* ㄘ */, "\xE3\x84\x9D" /* ㄝ */ },
+        { "g " /* ㄓ */, "\xE3\x84\x90" /* ㄐ */ },
+        { "h " /* ㄦ */, "\xE3\x84\x8F" /* ㄏ */ },
+        { "l " /* ㄥ */, "\xE3\x84\x8C" /* ㄌ */ },
+        { "c " /* ㄕ */, "\xE3\x84\x92" /* ㄒ */ },
+        { "n " /* ㄣ */, "\xE3\x84\x8B" /* ㄋ */ },
+        { "m " /* ㄢ */, "\xE3\x84\x87" /* ㄇ */ },
+        { "d " /* ㄉ */, "\xCB\x99" /* ˙ */ },
+        { "f " /* ㄈ */, "\xCB\x8A" /* ˊ */ },
+        { "j " /* ㄖ */, "\xCB\x87" /* ˇ */ },
+        { "k " /* ㄎ */, "\xCB\x8B" /* ˋ */ },
+        { "q " /* ㄗ */, "\xE3\x84\x9F" /* ㄟ */ },
+        { "v " /* ㄍ */, "\xE3\x84\x91" /* ㄑ */ },
+    };
+
+    size_t i;
+    ChewingContext *ctx;
+    int totalChoice;
+    const char *cand;
+
+    ctx = chewing_new();
+    start_testcase(ctx, fd);
+    chewing_set_KBType(ctx, KB_ET26);
+
+    for (i = 0; i < ARRAY_SIZE(CHOICE_INFO_APPEND); ++i) {
+
+        type_keystroke_by_string(ctx, CHOICE_INFO_APPEND[i].token);
+
+        chewing_cand_open(ctx);
+        totalChoice = chewing_cand_TotalChoice(ctx);
+
+        if (i == 13 || i == 14) {
+            cand = chewing_cand_string_by_index_static(ctx, totalChoice - 2);
+        } else {
+            cand = chewing_cand_string_by_index_static(ctx, totalChoice - 1);
+        }
+
+        ok(strcmp(cand, CHOICE_INFO_APPEND[i].expected) == 0, "returned candidate is `%s' shall be `%s'", cand, CHOICE_INFO_APPEND[i].expected);
+
+        chewing_cand_close(ctx);
+        chewing_clean_preedit_buf(ctx);
+    }
+    chewing_delete(ctx);
+}
 
 void test_KB_DACHEN_CP26()
 {
@@ -1683,7 +1782,9 @@ void test_KB_MPS2()
 void test_KB()
 {
     test_KB_HSU();
+    test_KB_HSU_choice_append();
     test_KB_ET26();
+    test_KB_ET26_choice_append();
     test_KB_DACHEN_CP26();
 
     test_KB_HANYU();


### PR DESCRIPTION
倚天26鍵和許氏鍵盤相同，將兩個注音符號配置到同一鍵，
所以要將其中一個的候選字加到另一個的清單中。
libchewing 已經實做許氏的部份，現在加上倚天26鍵。
- src/choice.c
   Add ET26 to ChoiceInfoAppendChi()
- test/test-bopomofo.c
   Update test cases for both ET26 and HSU
