### PR TITLE
userphrase-hash: avoid double free in TerminateUserphrase

### DIFF
--- a/src/userphrase-hash.c
+++ b/src/userphrase-hash.c
@@ -196,6 +196,7 @@ int UserRemovePhrase(ChewingData *pgdata, const uint16_t phoneSeq[], const char 
             HashModify(pgdata, item);
 
             *prev = item->next;
+            item->next = NULL;
             FreeHashItem(item);
 
             return 1;

--- a/test/test-userphrase.c
+++ b/test/test-userphrase.c
@@ -724,6 +724,39 @@ void test_userphrase_lookup()
     chewing_delete(ctx);
 }
 
+void test_userphrase_double_free()
+{
+    ChewingContext *ctx = NULL;
+    char p1[] = "\xE6\xB8\xAC";
+    char p2[] = "\xE7\xAD\x96";
+    char b1[] = "\xE3\x84\x98\xE3\x84\x9C\xCB\x8B";
+    int ret = 0;
+
+    clean_userphrase();
+
+    start_testcase(ctx, fd);
+
+    ctx = chewing_new();
+    ret = chewing_userphrase_add(ctx, p1, b1);
+    ok(ret == 1, "chewing_userphrase_add() return value `%d' shall be `%d'", ret, 1);
+    ret = chewing_userphrase_add(ctx, p2, b1);
+    ok(ret == 1, "chewing_userphrase_add() return value `%d' shall be `%d'", ret, 1);
+    ret = chewing_userphrase_remove(ctx, p1, b1);
+    ok(ret == 1, "chewing_userphrase_remove() return value `%d' shall be `%d'", ret, 1);
+    chewing_delete(ctx);
+    ctx = NULL;
+
+    ctx = chewing_new();
+    ret = chewing_userphrase_add(ctx, p1, b1);
+    ok(ret == 1, "chewing_userphrase_add() return value `%d' shall be `%d'", ret, 1);
+    ret = chewing_userphrase_add(ctx, p2, b1);
+    ok(ret == 1, "chewing_userphrase_add() return value `%d' shall be `%d'", ret, 1);
+    chewing_userphrase_remove(ctx, p1, b1);
+    ok(ret == 1, "chewing_userphrase_remove() return value `%d' shall be `%d'", ret, 1);
+    chewing_delete(ctx);
+    ctx = NULL;
+}
+
 int main(int argc, char *argv[])
 {
     char *logname;
@@ -746,6 +779,7 @@ int main(int argc, char *argv[])
     test_userphrase_enumerate();
     test_userphrase_manipulate();
     test_userphrase_lookup();
+    test_userphrase_double_free();
 
     fclose(fd);
 


### PR DESCRIPTION
When a userphrase which has cascading items to be removed by chewing_userphrase_remove,
all of these cascading items will be freed in FreeHashItem.
However, the TerminateUserphrase  will also try to use FreeHashItem to release these items again in chewing_delete.
It causes malloc error: "pointer being freed was not allocated" on macOS.
This PR is to isolate the userphrase-to-be-removed by setting its next-ptr to be NULL.
As for its cascading items, they will be freed by TerminateUserphrase.

##### Test Case:
```
#include <chewing.h>
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <stdarg.h>
#include <unistd.h>

int main (void)
{
    ChewingContext *ctx = NULL;

    const char p1[] = "測";
    const char p2[] = "冊";
    const char b[]  = "ㄘㄜˋ";

    ctx = chewing_new();
    chewing_userphrase_add(ctx, p1, b);
    chewing_userphrase_add(ctx, p2, b);
    chewing_userphrase_remove(ctx, p1, b);

    chewing_delete(ctx);

    return 0;
}
```

##### Compile
``gcc -Wall -I/opt/local/include/chewing -c chewing_userphrase_double_free.c``
``gcc -Wall -I/opt/local/include/chewing  -L/opt/local/lib -lchewing chewing_userphrase_double_free.o -o chewing_userphrase_double_free``

##### Execute
1. ``rm -rf ~/.chewing``
2. execute ``./chewing_userphrase_double_free``
3. execute again ``./chewing_userphrase_double_free``
> chewing_userphrase_double_free(40031,0x7fff7be0b000) malloc: *** error for object 0x7fe248c03270: pointer being freed was not allocated
