### PR TITLE
hash: fix hash item offset calculating in uhash.dat

### DIFF
--- a/include/internal/hash-private.h
+++ b/include/internal/hash-private.h
@@ -45,7 +45,7 @@ void DestroyUserPhraseData(UserPhraseData* pData);
 int InitUserphrase(struct ChewingData *pgdata, const char *path);
 void TerminateUserphrase(struct ChewingData *pgdata);
 void FreeHashTable(void);
-int HashFileOffsetWithUserPhrase(struct ChewingData *pgdata, HASH_ITEM *pItem);
+int HashFileSeekToUserPhrase(struct ChewingData *pgdata, HASH_ITEM *pItem, FILE *fpHash);
 
 /* *INDENT-OFF* */
 #endif

--- a/include/internal/hash-private.h
+++ b/include/internal/hash-private.h
@@ -45,6 +45,7 @@ void DestroyUserPhraseData(UserPhraseData* pData);
 int InitUserphrase(struct ChewingData *pgdata, const char *path);
 void TerminateUserphrase(struct ChewingData *pgdata);
 void FreeHashTable(void);
+int HashFileOffsetWithUserPhrase(struct ChewingData *pgdata, HASH_ITEM *pItem);
 
 /* *INDENT-OFF* */
 #endif

--- a/src/hash.c
+++ b/src/hash.c
@@ -616,17 +616,15 @@ int HashFileSeekToUserPhrase(struct ChewingData *pgdata, HASH_ITEM *pItem, FILE 
     fsize = ftell(fpHash);
 
     buf = ALC(char, fsize);
-    if (!buf)
-    {
-        free (pItemTmp);
+    if (!buf) {
+        free(pItemTmp);
         return 0;
     }
 
     fseek(fpHash, 0, SEEK_SET);
-    if (fread(buf, fsize, 1, fpHash) != 1)
-    {
-        free (pItemTmp);
-        free (buf);
+    if (fread(buf, fsize, 1, fpHash) != 1) {
+        free(pItemTmp);
+        free(buf);
         return 0;
     }
 
@@ -652,8 +650,8 @@ int HashFileSeekToUserPhrase(struct ChewingData *pgdata, HASH_ITEM *pItem, FILE 
         item_index++;
     }
 
-    free (pItemTmp);
-    free (buf);
+    free(pItemTmp);
+    free(buf);
     return result;
 }
 

--- a/src/hash.c
+++ b/src/hash.c
@@ -607,8 +607,10 @@ int HashFileOffsetWithUserPhrase(struct ChewingData *pgdata, HASH_ITEM *pItem)
     int fsize  = 0;
     int len    = 0;
     int offset = strlen(BIN_HASH_SIG) + sizeof(pgdata->static_data.chewing_lifetime);
+    int found  = 0;
 
-    char *seekhead = _load_hash_file(pgdata->static_data.hashfilename, &fsize);
+    char *fhead    = _load_hash_file(pgdata->static_data.hashfilename, &fsize);
+    char *seekhead = fhead;
     char *wordSeq  = NULL;
 
     const char *pc;
@@ -630,9 +632,10 @@ int HashFileOffsetWithUserPhrase(struct ChewingData *pgdata, HASH_ITEM *pItem)
         if ((int)(seekhead[16]) &&
             strlen(wordSeq) == strlen(pItem->data.wordSeq) &&
             !strncmp(wordSeq, pItem->data.wordSeq, strlen(pItem->data.wordSeq))) {
-            free (wordSeq);
+            free(wordSeq);
             wordSeq = NULL;
-            return offset;
+            found = 1;
+            break;
         }
 
         seekhead += FIELD_SIZE;
@@ -642,6 +645,8 @@ int HashFileOffsetWithUserPhrase(struct ChewingData *pgdata, HASH_ITEM *pItem)
         wordSeq = NULL;
     }
 
-    return -1;
+    free(fhead);
+    fhead = NULL;
+    return (found ? offset : -1);
 }
 

--- a/src/hash.c
+++ b/src/hash.c
@@ -610,18 +610,25 @@ int HashFileSeekToUserPhrase(struct ChewingData *pgdata, HASH_ITEM *pItem, FILE 
 
     pItemTmp = ALC(HASH_ITEM, 1);
     if (!pItemTmp)
-        goto error;
+        return 0;
 
     fseek(fpHash, 0, SEEK_END);
     fsize = ftell(fpHash);
 
     buf = ALC(char, fsize);
     if (!buf)
-        goto error;
+    {
+        free (pItemTmp);
+        return 0;
+    }
 
     fseek(fpHash, 0, SEEK_SET);
     if (fread(buf, fsize, 1, fpHash) != 1)
-        goto error;
+    {
+        free (pItemTmp);
+        free (buf);
+        return 0;
+    }
 
     hdrlen = strlen(BIN_HASH_SIG) + sizeof(pgdata->static_data.chewing_lifetime);
     seekdump = buf + hdrlen;
@@ -645,7 +652,6 @@ int HashFileSeekToUserPhrase(struct ChewingData *pgdata, HASH_ITEM *pItem, FILE 
         item_index++;
     }
 
-error:
     free (pItemTmp);
     free (buf);
     return result;

--- a/src/userphrase-hash.c
+++ b/src/userphrase-hash.c
@@ -192,7 +192,6 @@ int UserRemovePhrase(ChewingData *pgdata, const uint16_t phoneSeq[], const char 
         if (strcmp(item->data.wordSeq, wordSeq) == 0) {
             /* Remove this phrase by removing */
             item->data.phoneSeq[0] = 0;
-            item->data.wordSeq[0] = 0;
             HashModify(pgdata, item);
 
             *prev = item->next;

--- a/test/test-userphrase.c
+++ b/test/test-userphrase.c
@@ -787,7 +787,7 @@ void test_userphrase_remove()
 
     ctx = chewing_new();
     ret = chewing_userphrase_lookup(ctx, p2, b1);
-    ok(ret == 0, "chewing_userphrase_lookup() return value `%d' shall be `%d'", ret, 1);
+    ok(ret == 0, "chewing_userphrase_lookup() return value `%d' shall be `%d'", ret, 0);
     chewing_delete(ctx);
     ctx = NULL;
 }

--- a/test/test-userphrase.c
+++ b/test/test-userphrase.c
@@ -757,6 +757,42 @@ void test_userphrase_double_free()
     ctx = NULL;
 }
 
+void test_userphrase_remove()
+{
+    ChewingContext *ctx = NULL;
+    char p1[] = "\xE6\xB8\xAC";
+    char p2[] = "\xE7\xAD\x96";
+    char b1[] = "\xE3\x84\x98\xE3\x84\x9C\xCB\x8B";
+    int ret = 0;
+
+    clean_userphrase();
+
+    start_testcase(ctx, fd);
+
+    ctx = chewing_new();
+    ret = chewing_userphrase_add(ctx, p1, b1);
+    ok(ret == 1, "chewing_userphrase_add() return value `%d' shall be `%d'", ret, 1);
+    ret = chewing_userphrase_add(ctx, p2, b1);
+    ok(ret == 1, "chewing_userphrase_add() return value `%d' shall be `%d'", ret, 1);
+    ret = chewing_userphrase_remove(ctx, p1, b1);
+    ok(ret == 1, "chewing_userphrase_remove() return value `%d' shall be `%d'", ret, 1);
+    chewing_delete(ctx);
+    ctx = NULL;
+
+    ctx = chewing_new();
+    ret = chewing_userphrase_remove(ctx, p2, b1);
+    ok(ret == 1, "chewing_userphrase_remove() return value `%d' shall be `%d'", ret, 1);
+    chewing_delete(ctx);
+    ctx = NULL;
+
+    ctx = chewing_new();
+    ret = chewing_userphrase_lookup(ctx, p2, b1);
+    ok(ret == 0, "chewing_userphrase_lookup() return value `%d' shall be `%d'", ret, 1);
+    chewing_delete(ctx);
+    ctx = NULL;
+}
+
+
 int main(int argc, char *argv[])
 {
     char *logname;
@@ -780,6 +816,7 @@ int main(int argc, char *argv[])
     test_userphrase_manipulate();
     test_userphrase_lookup();
     test_userphrase_double_free();
+    test_userphrase_remove();
 
     fclose(fd);
 

--- a/test/test-userphrase.c
+++ b/test/test-userphrase.c
@@ -792,7 +792,6 @@ void test_userphrase_remove()
     ctx = NULL;
 }
 
-
 int main(int argc, char *argv[])
 {
     char *logname;


### PR DESCRIPTION
When a userphrase is going to be removed, HashModify calculates the offset according to its item_index.
```
pItem->item_index * FIELD_SIZE + 4 + strlen(BIN_HASH_SIG)
```

However, the item_index will be shifted if there has previously removed item in uhash.dat.

Considering the following example:
chewing_userphrase_add(ctx, p1, b)
chewing_userphrase_add(ctx, p2, b)

| item_index | wordSeq | offset in uhash.dat |
| ---------- | ------- | ------------------- |
| 0          | p1      | 8                   |
| 1          | p2      | 133                 |

chewing_userphrase_remove(ctx, p1, b)

| item_index | wordSeq | offset in uhash.dat |
| ---------- | ------- | ------------------- |
|            | p1'     | 8                   |
| 1          | p2      | 133                 |

When libchewing restarts, InitUserphrase calls ReadHashItem_bin, it will find that p1' is invalid.
So the item_index of p2 will be set to 0.

| item_index | wordSeq | offset in uhash.dat |
| ---------- | ------- | ------------------- |
|            | p1'     | 8                   |
| 0          | p2      | 133                 |

When p2 is going to be removed, the offset of p2 in uhash.dat will be wrong.
```
pItem->item_index * FIELD_SIZE + 4 + strlen(BIN_HASH_SIG)
= 0 * FIELD_SIZE + 4 + strlen(BIN_HASH_SIG)
= 8
```
In this case, chewing_userphrase_remove returns success, but p2 won't be removed (marked as invalid) in uhash.dat.
Next time the libchewing starts, p2 will still be there since it is valid in uhash.dat.
Moreover, this problem could also impact the userphrase modification, or deletes an unexcepted one in uhash.dat.

This fix tries to find the physical offset in uhash.dat based on the wordSeq.
By this method, HashModify will update the correct record in uhash.dat.
