### PR TITLE
Fix ChoiceEndChoice expression always true

### DIFF
--- a/src/choice.c
+++ b/src/choice.c
@@ -523,11 +523,9 @@ int ChoiceEndChoice(ChewingData *pgdata)
     pgdata->choiceInfo.nTotalChoice = 0;
     pgdata->choiceInfo.nPage = 0;
 
-    if (pgdata->choiceInfo.isSymbol != WORD_CHOICE || pgdata->choiceInfo.isSymbol != SYMBOL_CHOICE_INSERT) {
-        /* return to the old chiSymbolCursor position */
-        pgdata->chiSymbolCursor = pgdata->choiceInfo.oldChiSymbolCursor;
-        assert(pgdata->chiSymbolCursor <= pgdata->chiSymbolBufLen);
-    }
+    pgdata->chiSymbolCursor = pgdata->choiceInfo.oldChiSymbolCursor;
+    assert(pgdata->chiSymbolCursor <= pgdata->chiSymbolBufLen);
+
     pgdata->choiceInfo.isSymbol = WORD_CHOICE;
     return 0;
 }


### PR DESCRIPTION
The chiSymbolCursor should be placed back to old position no matter which type of choice selection is finished.
The original expression wants to check the type of choice, then set the chiSymbolCursor to old position, but the expression is always true. The chiSymbolCursor should place back to old position after finishing the choice selection in any case, so removing the if statement.