### PR TITLE
Update jvc-convert of KB layout Hsu

### DIFF
--- a/src/bopomofo.c
+++ b/src/bopomofo.c
@@ -242,6 +242,9 @@ static int HsuPhoInput(ChewingData *pgdata, int key)
                     && (pBopomofo->pho_inx[0] || pBopomofo->pho_inx[1])) {
                     /* if inx !=0 */
                     searchTimes = 2;    /* possible infinite loop here */
+                } else if (12 <= inx && inx <= 14) {
+                    /* ㄐㄑㄒ always come with ㄧㄩ, so set ㄓㄔㄕ as default. */
+                    pBopomofo->pho_inx[0] = inx + 3;
                 } else
                     break;
             } else if (type == 1 && inx == 1) { /* handle i and e */
@@ -258,15 +261,18 @@ static int HsuPhoInput(ChewingData *pgdata, int key)
             pBopomofo->pho_inx[0] = 12;
         }
 
-        /* ㄐㄑㄒ must be followed by ㄧㄩ, if not, convert them to ㄓㄔㄕ */
-        if (type == 1 && inx == 2 && 12 <= pBopomofo->pho_inx[0] && pBopomofo->pho_inx[0] <= 14) {
-            /* followed by ㄨ */
-            pBopomofo->pho_inx[0] += 3;
+        /* ㄐㄑㄒ must be followed by ㄧ or ㄩ. If not, convert them to ㄓㄔㄕ. */
+        if (12 <= pBopomofo->pho_inx[0] && pBopomofo->pho_inx[0] <= 14) {
+	        if ((type == 1 && inx == 2) || (type == 2 && pBopomofo->pho_inx[1] == 0)) {
+		        pBopomofo->pho_inx[0] += 3;
+	        }
         }
 
-        if (type == 2 && pBopomofo->pho_inx[1] == 0 && 12 <= pBopomofo->pho_inx[0] && pBopomofo->pho_inx[0] <= 14) {
-            /* followed by other phones */
-            pBopomofo->pho_inx[0] += 3;
+        /* Likeweis, when ㄓㄔㄕ is followed by ㄧ or ㄩ, convert them to ㄐㄑㄒ. */
+        if (15 <= pBopomofo->pho_inx[0] && pBopomofo->pho_inx[0] <= 17) {
+	        if ((type == 1) && (inx == 1 || inx == 3)) {
+		        pBopomofo->pho_inx[0] -= 3;
+	        }
         }
 
         if (type == 3) {        /* the key is NOT a phone */

--- a/test/test-bopomofo.c
+++ b/test/test-bopomofo.c
@@ -1450,13 +1450,6 @@ void test_KB_HSU()
     ok_preedit_buffer(ctx, "\xE9\xAA\xAF" /* 骯 */);
     chewing_clean_preedit_buf(ctx);
 
-    type_keystroke_by_string(ctx, "j");
-    ok_bopomofo_buffer(ctx, "\xE3\x84\x90" /* ㄐ */);
-    type_keystroke_by_string(ctx, " "); /* convert "ㄐ,ㄑ,ㄒ" to "ㄓ,ㄔ,ㄕ" */
-    ok_bopomofo_buffer(ctx, "");
-    ok_preedit_buffer(ctx, "\xE4\xB9\x8B" /* 之 */);
-    chewing_clean_preedit_buf(ctx);
-
     type_keystroke_by_string(ctx, "l");
     ok_bopomofo_buffer(ctx, "\xE3\x84\x8C" /* ㄌ */);
     type_keystroke_by_string(ctx, "f"); /* convert "ㄌ" to "ㄦ" */
@@ -1515,6 +1508,47 @@ void test_KB_HSU_choice_append()
         chewing_cand_close(ctx);
         chewing_clean_preedit_buf(ctx);
     }
+    chewing_delete(ctx);
+}
+
+void test_KB_HSU_JVC()
+{
+    static const struct {
+        char *keystroke;
+        char *bopomofo;
+        char *cand;
+    } DATA[] = {
+        { "j", "\xE3\x84\x93", /* ㄓ */ "\xE4\xB9\x8B", /* 之 */ },
+        { "v", "\xE3\x84\x94", /* ㄔ */ "\xE5\x90\x83", /* 吃 */ },
+        { "c", "\xE3\x84\x95", /* ㄕ */ "\xE5\xA4\xB1", /* 失 */ },
+    };
+
+    ChewingContext *ctx;
+    ctx = chewing_new();
+    start_testcase(ctx, fd);
+    chewing_set_KBType(ctx, KB_HSU);
+
+    for (int i = 0; i < ARRAY_SIZE(DATA); ++i) {
+        type_keystroke_by_string(ctx, DATA[i].keystroke);
+        ok_bopomofo_buffer(ctx, DATA[i].bopomofo);
+        type_keystroke_by_string(ctx, " ");
+        ok_bopomofo_buffer(ctx, "");
+        ok_preedit_buffer(ctx, DATA[i].cand);
+
+        chewing_cand_close(ctx);
+        chewing_clean_preedit_buf(ctx);
+    }
+
+    type_keystroke_by_string(ctx, "cek");
+    ok_bopomofo_buffer(ctx, "\xE3\x84\x92\xE3\x84\xA7\xE3\x84\xA4" /* ㄒㄧㄤ */ );
+    type_keystroke_by_string(ctx, "<EE>");
+
+    type_keystroke_by_string(ctx, "cke");
+    ok_bopomofo_buffer(ctx, "\xE3\x84\x92\xE3\x84\xA7\xE3\x84\xA4" /* ㄒㄧㄤ */ );
+    type_keystroke_by_string(ctx, "<B><B>k");
+    ok_bopomofo_buffer(ctx, "\xE3\x84\x95\xE3\x84\xA4" /* ㄕㄤ */ );
+    chewing_clean_preedit_buf(ctx);
+
     chewing_delete(ctx);
 }
 
@@ -1783,6 +1817,7 @@ void test_KB()
 {
     test_KB_HSU();
     test_KB_HSU_choice_append();
+    test_KB_HSU_JVC();
     test_KB_ET26();
     test_KB_ET26_choice_append();
     test_KB_DACHEN_CP26();


### PR DESCRIPTION
 1. 增補ㄓㄔㄕ→ㄐㄑㄒ轉換。
許氏的ㄐㄑㄒ和ㄓㄔㄕ是在同一個按鍵，有介音ㄧ或ㄩ的時候，ㄓㄔㄕ才會轉換成ㄐㄑㄒ。但目前 libchewing 只有ㄐㄑㄒ轉ㄓㄔㄕ，沒有ㄓㄔㄕ轉ㄐㄑㄒ。因此，若使用者先輸入韻母才輸入介音，就無法正確的出字。例如：使用者想輸入「鄉」，但在快速打字的時候出錯，順序變成 ``ㄒ → ㄤ → 一``，這時ㄒ會因為ㄤ而轉換成ㄕ，等到輸入ㄧ的時候卻沒有再換回ㄒ，變成 ``ㄕㄧㄤ``。[1]

 2. 按下 jvc 時，優先輸出ㄓㄔㄕ。
ㄓㄔㄕ本身加聲調就可以出字，而ㄐㄑㄒ不行。但目前 libchewing 是按下 jvc 鍵時先輸出ㄐㄑㄒ到預編區，等按聲調的時候才轉換成ㄓㄔㄕ，所以使用者看見的是輸入ㄐ卻得到ㄓ的字（之、知、隻等等），這樣比較不直覺，也和自然輸入法的行為相反，所以改為先輸出ㄓㄔㄕ。

 3. 更新 test case。


[1] https://groups.google.com/d/msg/chewing-devel/D8MMq_sRxnU/KZ3ucglaAAAJ