### PR TITLE
Auto learn phrases only after committing

### DIFF
--- a/src/choice.c
+++ b/src/choice.c
@@ -530,24 +530,12 @@ int ChoiceEndChoice(ChewingData *pgdata)
     return 0;
 }
 
-static void ChangeUserData(ChewingData *pgdata, int selectNo)
-{
-    uint16_t userPhoneSeq[MAX_PHONE_SEQ_LEN];
-    int len;
-
-    len = ueStrLen(pgdata->choiceInfo.totalChoiceStr[selectNo]);
-    memcpy(userPhoneSeq, &(pgdata->phoneSeq[PhoneSeqCursor(pgdata)]), len * sizeof(uint16_t));
-    userPhoneSeq[len] = 0;
-    UserUpdatePhrase(pgdata, userPhoneSeq, pgdata->choiceInfo.totalChoiceStr[selectNo]);
-}
-
 /** @brief commit the selected phrase. */
 int ChoiceSelect(ChewingData *pgdata, int selectNo)
 {
     ChoiceInfo *pci = &(pgdata->choiceInfo);
     AvailInfo *pai = &(pgdata->availInfo);
 
-    ChangeUserData(pgdata, selectNo);
     ChangeSelectIntervalAndBreakpoint(pgdata,
                                       PhoneSeqCursor(pgdata),
                                       PhoneSeqCursor(pgdata) + pai->avail[pai->currentAvail].len,


### PR DESCRIPTION
 * src/choice.c
   Currently, after users select a candidate on the list, libchewing
   saves it as an one-word-phrase into the userphrase bank. However,
   this is not desirable, especially when the users picked a wrong
   candidte.

   Libchewing should learn phrases only after the users press
   Enter and commit.

   This also prevents the userphrase database from growing fast.

 * test/test-userphrase.c
   Fix and update test cases.