### PR TITLE
Implement chewing_set_autoLearn() and chewing_get_autoLearn()

### DIFF
--- a/doc/libchewing.texi
+++ b/doc/libchewing.texi
@@ -1174,6 +1174,21 @@ before the cursor or after the cursor.
 This function returns the phrase choice rearward setting.
 @end deftypefun
 
+@deftypefun void chewing_set_autoLearn (ChewingContext *@var{ctx}, int @var{mode})
+This function can be used to enable or disable the automatic learning.
+
+The @var{mode} argument is be one of the @code{AUTOLEARN_ENABLED} and @code{AUTOLEARN_DISABLED} macros.
+@end deftypefun
+
+@deftypevr  Macro int AUTOLEARN_ENABLED
+@deftypevrx Macro int AUTOLEARN_DISABLED
+Indicate whether the automatic learning is enabled or not.
+@end deftypevr
+
+@deftypefun int chewing_get_autoLearn (const ChewingContext *@var{ctx})
+This function returns whether the automatic learning is enabled or disabled.
+@end deftypefun
+
 @node Variable Index
 @unnumbered Variable Index
 

--- a/include/chewingio.h
+++ b/include/chewingio.h
@@ -498,6 +498,30 @@ CHEWING_API int chewing_get_phraseChoiceRearward(const ChewingContext *ctx);
 /*@}*/
 
 
+/*! \name Behavior of automatic learning after committing
+ */
+
+/*@{*/
+/**
+ * @brief Set the behavior of automatic learning
+ *
+ * @param ctx
+ * @param mode AUTOLEARN_ENABLED or AUTOLEARN_DISABLED
+ */
+CHEWING_API void chewing_set_autoLearn(ChewingContext *ctx, int mode);
+
+
+/**
+ * @brief Get the behavior of automatic learning
+ *
+ * @param ctx
+ * @return AUTOLEARN_ENABLED or AUTOLEARN_DISABLED
+ */
+CHEWING_API int chewing_get_autoLearn(const ChewingContext *ctx);
+
+/*@}*/
+
+
 /*! \name Phonetic sequence in Chewing internal state machine
  */
 

--- a/include/global.h
+++ b/include/global.h
@@ -26,6 +26,8 @@
 #define SYMBOL_MODE 0
 #define FULLSHAPE_MODE 1
 #define HALFSHAPE_MODE 0
+#define AUTOLEARN_DISABLED 1
+#define AUTOLEARN_ENABLED 0
 
 /* specified to Chewing API */
 #if defined(_WIN32) || defined(_WIN64) || defined(_WIN32_WCE)
@@ -119,6 +121,7 @@ typedef struct ChewingConfigData {
     int bAutoShiftCur;
     int bEasySymbolInput;
     int bPhraseChoiceRearward;
+    int bAutoLearn;
     int hsuSelKeyType;          // Deprecated.
 } ChewingConfigData;
 

--- a/src/chewingio.c
+++ b/src/chewingio.c
@@ -743,6 +743,35 @@ CHEWING_API int chewing_get_ShapeMode(const ChewingContext *ctx)
     return ctx->data->bFullShape;
 }
 
+CHEWING_API void chewing_set_autoLearn(ChewingContext *ctx, int mode)
+{
+    ChewingData *pgdata;
+
+    if (!ctx) {
+        return;
+    }
+    pgdata = ctx->data;
+
+    LOG_API("mode = %d", mode);
+
+    if (mode == AUTOLEARN_ENABLED || mode == AUTOLEARN_DISABLED)
+        ctx->data->config.bAutoLearn = mode;
+}
+
+CHEWING_API int chewing_get_autoLearn(const ChewingContext *ctx)
+{
+    const ChewingData *pgdata;
+
+    if (!ctx) {
+        return -1;
+    }
+    pgdata = ctx->data;
+
+    LOG_API("bAutoLearn = %d", ctx->data->config.bAutoLearn);
+
+    return ctx->data->config.bAutoLearn;
+}
+
 static void CheckAndResetRange(ChewingData *pgdata)
 {
     if (pgdata->PointStart > -1) {
@@ -907,7 +936,9 @@ CHEWING_API int chewing_handle_Enter(ChewingContext *ctx)
     } else {
         keystrokeRtn = KEYSTROKE_COMMIT;
         WriteChiSymbolToCommitBuf(pgdata, pgo, nCommitStr);
-        AutoLearnPhrase(pgdata);
+        if (!pgdata->config.bAutoLearn) {
+            AutoLearnPhrase(pgdata);
+        }
         CleanAllBuf(pgdata);
         pgo->commitBufLen = nCommitStr;
     }
@@ -2303,7 +2334,9 @@ CHEWING_API int chewing_commit_preedit_buf(ChewingContext *ctx)
         return -1;
 
     WriteChiSymbolToCommitBuf(pgdata, pgo, len);
-    AutoLearnPhrase(pgdata);
+    if (!pgdata->config.bAutoLearn) {
+        AutoLearnPhrase(pgdata);
+    }
     CleanAllBuf(pgdata);
 
     MakeOutputWithRtn(pgo, pgdata, KEYSTROKE_COMMIT);

--- a/src/compat.c
+++ b/src/compat.c
@@ -56,6 +56,7 @@ CHEWING_API int chewing_Configure(ChewingContext *ctx, ChewingConfigData * pcd)
     chewing_set_autoShiftCur(ctx, pcd->bAutoShiftCur);
     chewing_set_easySymbolInput(ctx, pcd->bEasySymbolInput);
     chewing_set_phraseChoiceRearward(ctx, pcd->bPhraseChoiceRearward);
+    chewing_set_autoLearn(ctx, pcd->bAutoLearn);
 
     return 0;
 }

--- a/test/test-config.c
+++ b/test/test-config.c
@@ -456,6 +456,39 @@ void test_set_ShapeMode()
     chewing_delete(ctx);
 }
 
+void test_set_autoLearn()
+{
+    const int VALUE[] = {
+        AUTOLEARN_ENABLED,
+        AUTOLEARN_DISABLED,
+    };
+
+    const int INVALID_VALUE[] = {
+        -1,
+        2,
+    };
+
+    ChewingContext *ctx;
+    size_t i;
+    size_t j;
+
+    ctx = chewing_new();
+    start_testcase(ctx, fd);
+
+    for (i = 0; i < ARRAY_SIZE(VALUE); ++i) {
+        chewing_set_autoLearn(ctx, VALUE[i]);
+        ok(chewing_get_autoLearn(ctx) == VALUE[i], "AutoLearn shall be `%d'", VALUE[i]);
+
+        for (j = 0; j < ARRAY_SIZE(INVALID_VALUE); ++j) {
+            // mode shall not change when set mode has invalid value.
+            chewing_set_autoLearn(ctx, INVALID_VALUE[j]);
+            ok(chewing_get_autoLearn(ctx) == VALUE[i], "AutoLearn shall be `%d'", VALUE[i]);
+        }
+    }
+
+    chewing_delete(ctx);
+}
+
 void test_deprecated()
 {
     ChewingContext *ctx;
@@ -574,6 +607,7 @@ int main(int argc, char *argv[])
     test_set_phraseChoiceRearward();
     test_set_ChiEngMode();
     test_set_ShapeMode();
+    test_set_autoLearn();
 
     test_deprecated();
 

--- a/test/test-struct-size.c
+++ b/test/test-struct-size.c
@@ -19,6 +19,7 @@ typedef struct OrigianlChewingConfigData {
     int bAutoShiftCur;
     int bEasySymbolInput;
     int bPhraseChoiceRearward;
+    int bAutoLearn;
     int hsuSelKeyType;
 } OrigianlChewingConfigData;
 

--- a/test/test-userphrase.c
+++ b/test/test-userphrase.c
@@ -242,8 +242,15 @@ void test_userphrase_auto_learn()
     ok(has_userphrase(ctx, bopomofo_1, NULL) == 0, "`%s' shall not be in userphrase", bopomofo_1);
     ok(has_userphrase(ctx, bopomofo_2, NULL) == 0, "`%s' shall not be in userphrase", bopomofo_2);
 
+    chewing_set_autoLearn(ctx, AUTOLEARN_DISABLED);
+    ok(chewing_get_autoLearn(ctx) == AUTOLEARN_DISABLED, "AutoLearn shall be `%d'", AUTOLEARN_DISABLED);
     type_keystroke_by_string(ctx, "dk dk dk hk4g4<E>");
+    ok(has_userphrase(ctx, bopomofo_1, NULL) == 0, "`%s' shall not be in userphrase", bopomofo_1);
+    ok(has_userphrase(ctx, bopomofo_2, NULL) == 0, "`%s' shall not be in userphrase", bopomofo_2);
 
+    chewing_set_autoLearn(ctx, AUTOLEARN_ENABLED);
+    ok(chewing_get_autoLearn(ctx) == AUTOLEARN_ENABLED, "AutoLearn shall be `%d'", AUTOLEARN_ENABLED);
+    type_keystroke_by_string(ctx, "dk dk dk hk4g4<E>");
     ok(has_userphrase(ctx, bopomofo_1, NULL) == 1, "`%s' shall be in userphrase", bopomofo_1);
     ok(has_userphrase(ctx, bopomofo_2, NULL) == 1, "`%s' shall be in userphrase", bopomofo_2);
 


### PR DESCRIPTION
Dear All,

I'm wondering if we can add a switch that allows users to disable the automatic learning function, like the 微軟新注音. 

This would be useful for users who want to keep their user-phrase database slim and organized.

Besides, ibus-chewing would need this feature for the 簡單注音模式. Under this mode, every single character that users input is stored into the user-phrase database.

Hopefully I did it correctly. Thanks!
