### PR TITLE
Travis-CI install higher version of cmake

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: c
 
 # container-based builds
-sudo: false
+sudo: required
 
 git:
   depth: 1
@@ -34,6 +34,10 @@ matrix:
 before_install:
   - pip install --user cpp-coveralls
   - P_JOBS="-j$(getconf _NPROCESSORS_ONLN)"
+  - yes | sudo add-apt-repository ppa:kalakris/cmake
+  - sudo apt-get update -qq
+
+install: sudo apt-get install cmake
 
 script:
   - if [ x$BUILD == xautotools ]; then ./autogen.sh && ./configure $CONFIGURE_OPTION && make $P_JOBS CFLAGS="$CFLAGS -Wall -Werror" && make $P_JOBS check && make $P_JOBS release && LC_ALL=c sort data/tsi.src > data/tsi.src.sort && diff data/tsi.src data/tsi.src.sort; fi


### PR DESCRIPTION
While the libchewing requires cmake version equal or higher then 2.8.8, but the default cmake version in Travis-CI is 2.8.7.
Install cmake from kalakris/cmake for higher version cmake.