### PR TITLE
[Fix #239] Reset oldChiSymbolCursor in chewing_handle_Default

### DIFF
--- a/include/internal/chewingutil.h
+++ b/include/internal/chewingutil.h
@@ -37,6 +37,7 @@ int SymbolChoice(ChewingData *pgdata, int sel_i);
 int HaninSymbolInput(ChewingData *pgdata);
 void WriteChiSymbolToCommitBuf(ChewingData *pgdata, ChewingOutput *pgo, int len);
 int ReleaseChiSymbolBuf(ChewingData *pgdata, ChewingOutput *);
+void ResetOldChiSymbolCursor(ChewingData *pgdata);
 int AddChi(uint16_t phone, uint16_t phoneAlt, ChewingData *pgdata);
 int CallPhrasing(ChewingData *pgdata, int all_phrasing);
 int MakeOutputWithRtn(ChewingOutput *pgo, ChewingData *pgdata, int keystrokeRtn);

--- a/src/chewingio.c
+++ b/src/chewingio.c
@@ -1625,6 +1625,7 @@ CHEWING_API int chewing_handle_Default(ChewingContext *ctx, int key)
   End_KeyDefault:
     CallPhrasing(pgdata, 0);
   End_Paging:
+    ResetOldChiSymbolCursor(pgdata);
     MakeOutputWithRtn(pgo, pgdata, keystrokeRtn);
     return 0;
 }

--- a/src/chewingutil.c
+++ b/src/chewingutil.c
@@ -529,6 +529,12 @@ int ReleaseChiSymbolBuf(ChewingData *pgdata, ChewingOutput *pgo)
     return throwEnd;
 }
 
+/* Sync the oldChiSymbolCursor after choice */
+void ResetOldChiSymbolCursor(ChewingData *pgdata)
+{
+    pgdata->choiceInfo.oldChiSymbolCursor = pgdata->chiSymbolCursor;
+}
+
 static int ChewingIsBreakPoint(int cursor, ChewingData *pgdata)
 {
     static const char *const BREAK_WORD[] = {

--- a/src/choice.c
+++ b/src/choice.c
@@ -517,6 +517,10 @@ int ChoiceNextAvail(ChewingData *pgdata)
     return 0;
 }
 
+/* TODO:
+**     Distinguish in what situation the chiSymbolCursor should be
+** reset to the oldChiSymbolCursor
+*/
 int ChoiceEndChoice(ChewingData *pgdata)
 {
     pgdata->bSelect = 0;


### PR DESCRIPTION
This issue is because of the chiSymbolCursor be reset to incorrect
oldChiSymbolCursor.
This commit can prevent the chiSymbolCursor be reset to incorrect
oldChiSymbolCursor value happened in #239, because the
oldChiSymbolCursor will be reset as the current chiSymbolCursor
after chewing_handle_Default().