### PR TITLE
Clean Bopomofo properly when switching Chi-Eng Mode

### DIFF
--- a/src/chewingio.c
+++ b/src/chewingio.c
@@ -694,8 +694,7 @@ CHEWING_API void chewing_set_ChiEngMode(ChewingContext *ctx, int mode)
 
     if (mode == CHINESE_MODE || mode == SYMBOL_MODE) {
         // remove all data inside buffer as switching mode.
-        BopomofoRemoveAll(&(ctx->data->bopomofoData));
-        MakeOutputWithRtn(ctx->output, ctx->data, KEYSTROKE_ABSORB);
+        chewing_clean_bopomofo_buf(ctx);
         ctx->data->bChiSym = mode;
     }
 }

--- a/test/test-regression.c
+++ b/test/test-regression.c
@@ -107,6 +107,24 @@ void test_libchewing_issue_108()
     chewing_delete(ctx);
 }
 
+void test_libchewing_issue_194()
+{
+    ChewingContext *ctx;
+
+    clean_userphrase();
+
+    ctx = chewing_new();
+    start_testcase(ctx, fd);
+
+    chewing_set_ChiEngMode(ctx, SYMBOL_MODE);
+    type_keystroke_by_string(ctx, "test");
+    chewing_set_ChiEngMode(ctx, CHINESE_MODE);
+
+    ok_commit_buffer(ctx, "t");
+
+    chewing_delete(ctx);
+}
+
 void test_libchewing_data_issue_1()
 {
     const TestData DATA = { "e03y.3", "\xE8\xB6\x95\xE8\xB5\xB0" /* 趕走 */  };
@@ -142,6 +160,7 @@ int main(int argc, char *argv[])
     test_libchewing_data_issue_1();
     test_libchewing_issue_30();
     test_libchewing_issue_108();
+    test_libchewing_issue_194();
     test_libchewing_googlecode_issue_472();
     test_libchewing_googlecode_issue_473();
 


### PR DESCRIPTION
觀察 ``chewing_clean_bopomofo_buf()``，發現 Bopomofo 之後應該呼叫 ``MakeOutput()`` 即可，而不是 ``MakeOutputWithRtn``。

我將它改為直接使用  ``chewing_clean_bopomofo_buf()`` 。