### PR TITLE
Update chewing_handle_CtrlNum()

### DIFF
--- a/test/test-userphrase.c
+++ b/test/test-userphrase.c
@@ -114,6 +114,8 @@ void test_CtrlNum_add_phrase_right()
     static const char msg[] = "\xE5\x8A\xA0\xE5\x85\xA5\xEF\xBC\x9A\xE6\xB8\xAC\xE8\xA9\xA6" /* 加入：測試 */ ;
     static const char msg_already_have[] =
         "\xE5\xB7\xB2\xE6\x9C\x89\xEF\xBC\x9A\xE6\xB8\xAC\xE8\xA9\xA6" /* 已有：測試 */ ;
+
+    int ret;
     int cursor;
     ChewingContext *ctx;
 
@@ -136,6 +138,14 @@ void test_CtrlNum_add_phrase_right()
     type_keystroke_by_string(ctx, "<C2>");
     ok_aux_buffer(ctx, msg_already_have);
 
+    type_keystroke_by_string(ctx, "<EN><C2>");
+
+    ret = chewing_aux_Check(ctx);
+    ok(ret == 0, "chewing_aux_Check() returns `%d', shall be `0'", ret);
+
+    ret = chewing_aux_Length(ctx);
+    ok(ret == 0, "chewing_aux_Length() returns `%d', shall be `0'", ret);
+
     chewing_delete(ctx);
 }
 
@@ -146,6 +156,8 @@ void test_CtrlNum_add_phrase_left()
     static const char msg_add[] = "\xE5\x8A\xA0\xE5\x85\xA5\xEF\xBC\x9A\xE6\xB8\xAC\xE8\xA9\xA6" /* 加入：測試 */ ;
     static const char msg_already_have[] =
         "\xE5\xB7\xB2\xE6\x9C\x89\xEF\xBC\x9A\xE6\xB8\xAC\xE8\xA9\xA6" /* 已有：測試 */ ;
+
+    int ret;
     int cursor;
     ChewingContext *ctx;
 
@@ -167,6 +179,14 @@ void test_CtrlNum_add_phrase_left()
 
     type_keystroke_by_string(ctx, "<C2>");
     ok_aux_buffer(ctx, msg_already_have);
+
+    type_keystroke_by_string(ctx, "<H><C2>");
+
+    ret = chewing_aux_Check(ctx);
+    ok(ret == 0, "chewing_aux_Check() returns `%d', shall be `0'", ret);
+
+    ret = chewing_aux_Length(ctx);
+    ok(ret == 0, "chewing_aux_Length() returns `%d', shall be `0'", ret);
 
     chewing_delete(ctx);
 }

--- a/test/test-userphrase.c
+++ b/test/test-userphrase.c
@@ -219,12 +219,72 @@ void test_CtrlNum_add_phrase_left_symbol_in_between()
     chewing_delete(ctx);
 }
 
+void test_CtrlNum_add_phrase_right_start_with_symbol()
+{
+    static const char bopomofo[] =
+        "\xE3\x84\x89\xE3\x84\xA4\xCB\x87 \xE3\x84\x8A\xE3\x84\xA8\xCB\x87 \xE3\x84\x91\xE3\x84\xA7\xE3\x84\xA4\xCB\x8A" /* ㄉㄤˇ ㄊㄨˇ ㄑㄧㄤˊ */ ;
+    static const char phrase[] = "\xE6\x93\x8B\xE5\x9C\x9F\xE7\x89\x86"; /* 擋土牆 */
+
+    const char *const_buf;
+    ChewingContext *ctx;
+
+    clean_userphrase();
+    ctx = chewing_new();
+    start_testcase(ctx, fd);
+    chewing_set_maxChiSymbolLen(ctx, 16);
+    chewing_set_addPhraseDirection(ctx, 0);
+
+    ok(has_userphrase(ctx, bopomofo, NULL) == 0, "`%s' shall not be in userphrase", bopomofo);
+
+    type_keystroke_by_string(ctx, "`1hk4g42;3wj3fu;6<L><L><L><D>3<C3>");
+    ok(has_userphrase(ctx, bopomofo, NULL) == 1, "`%s' shall be in userphrase", bopomofo);
+
+    chewing_cand_open(ctx);
+    chewing_cand_Enumerate(ctx);
+    const_buf = chewing_cand_string_by_index_static(ctx, 0);
+    ok(strcmp(const_buf, phrase) == 0, "first candidate `%s' shall be `%s'", const_buf, phrase);
+
+    chewing_delete(ctx);
+} 
+
+void test_CtrlNum_add_phrase_left_start_with_symbol()
+{
+    static const char bopomofo[] =
+        "\xE3\x84\x89\xE3\x84\xA4\xCB\x87 \xE3\x84\x8A\xE3\x84\xA8\xCB\x87 \xE3\x84\x91\xE3\x84\xA7\xE3\x84\xA4\xCB\x8A" /* ㄉㄤˇ ㄊㄨˇ ㄑㄧㄤˊ */ ;
+    static const char phrase[] = "\xE6\x93\x8B\xE5\x9C\x9F\xE7\x89\x86"; /* 擋土牆 */
+
+    const char *const_buf;
+    ChewingContext *ctx;
+
+    clean_userphrase();
+    ctx = chewing_new();
+    start_testcase(ctx, fd);
+    chewing_set_maxChiSymbolLen(ctx, 16);
+    chewing_set_addPhraseDirection(ctx, 1);
+
+    ok(has_userphrase(ctx, bopomofo, NULL) == 0, "`%s' shall not be in userphrase", bopomofo);
+
+    type_keystroke_by_string(ctx, "`1hk4g42;3wj3fu;6<L><L><L><D>3<EN><C3>");
+    ok(has_userphrase(ctx, bopomofo, NULL) == 1, "`%s' shall be in userphrase", bopomofo);
+
+    type_keystroke_by_string(ctx, "<L><L><L>");
+    chewing_cand_open(ctx);
+    chewing_cand_Enumerate(ctx);
+    const_buf = chewing_cand_string_by_index_static(ctx, 0);
+    ok(strcmp(const_buf, phrase) == 0, "first candidate `%s' shall be `%s'", const_buf, phrase);
+
+    chewing_delete(ctx);
+}
+
+
 void test_CtrlNum()
 {
     test_CtrlNum_add_phrase_right();
     test_CtrlNum_add_phrase_left();
     test_CtrlNum_add_phrase_right_symbol_in_between();
     test_CtrlNum_add_phrase_left_symbol_in_between();
+    test_CtrlNum_add_phrase_right_start_with_symbol();
+    test_CtrlNum_add_phrase_left_start_with_symbol();
 }
 
 void test_userphrase_auto_learn()


### PR DESCRIPTION
src/chewingio.c
  * NoSymbolBetween() and copyStringFromPreeditBuf() don't skip any
  non-chinese characters. They require the cursor of pre-edit buffer.
  * When users press ctrl + 2-9 but there is nothing to be added, for example, the pre-edit buffer is empty, libchewing will display the old aux message. This is not desirable. Set both pgdata->bShowMsg and pgdata->showMsgLen to 0 to clear and turn off the aux message. 

test/test-userphrase.c
  * Add test cases.


This should fix issue #232.