### PR TITLE
Fix: chewing_handle_Space() cannot input space when buffer is empty

### DIFF
--- a/src/chewingio.c
+++ b/src/chewingio.c
@@ -835,12 +835,12 @@ CHEWING_API int chewing_handle_Space(ChewingContext *ctx)
      * - "space as selection" mode is disable
      * - mode is not CHINESE_MODE
      * - has incompleted bopomofo (space is needed to complete it)
+     * - pre-edit buffer is empty
      */
-    if (!pgdata->config.bSpaceAsSelection || pgdata->bChiSym != CHINESE_MODE || BopomofoIsEntering(&ctx->data->bopomofoData)) {
+    if (!pgdata->config.bSpaceAsSelection || pgdata->bChiSym != CHINESE_MODE ||
+        BopomofoIsEntering(&ctx->data->bopomofoData) || pgdata->chiSymbolBufLen == 0) {
         return chewing_handle_Default(ctx, ' ');
     }
-
-    CheckAndResetRange(pgdata);
 
     /*
      * space = right when the follogin conditions are true
@@ -851,10 +851,9 @@ CHEWING_API int chewing_handle_Space(ChewingContext *ctx)
      */
     if (pgdata->bSelect && ctx->output->pci->pageNo < ctx->output->pci->nPage - 1) {
         return chewing_handle_Right(ctx);
-    } else {
-        return chewing_handle_Down(ctx);
     }
-    return 0;
+
+    return chewing_handle_Down(ctx);
 }
 
 CHEWING_API int chewing_handle_Esc(ChewingContext *ctx)

--- a/test/test-bopomofo.c
+++ b/test/test-bopomofo.c
@@ -1134,6 +1134,23 @@ void test_Numlock()
     test_Numlock_select_candidate();
 }
 
+void test_Space_empty_buffer()
+{
+    ChewingContext *ctx;
+
+    clean_userphrase();
+
+    ctx = chewing_new();
+    start_testcase(ctx, fd);
+    chewing_set_spaceAsSelection(ctx, 1);
+
+    type_keystroke_by_string(ctx, " ");
+    ok_preedit_buffer(ctx, "");
+    ok_commit_buffer(ctx, " ");
+
+    chewing_delete(ctx);
+}
+
 void test_Space_selection_word()
 {
     ChewingContext *ctx;
@@ -1205,6 +1222,7 @@ void test_Space_selection_symbol()
 
 void test_Space()
 {
+    test_Space_empty_buffer();
     test_Space_selection_word();
     test_Space_selection_symbol();
 }


### PR DESCRIPTION
The pre-edit buffer is empty, which means there's no need to open candidate list, chewing_handle_Space() should output a space.