### PR TITLE
Update chewing_handle_CtrlNum()

### DIFF
--- a/src/chewingio.c
+++ b/src/chewingio.c
@@ -1661,12 +1661,6 @@ CHEWING_API int chewing_handle_CtrlNum(ChewingContext *ctx, int key)
     ChewingData *pgdata;
     ChewingOutput *pgo;
     int keystrokeRtn = KEYSTROKE_ABSORB;
-    int newPhraseLen;
-    int i;
-    uint16_t addPhoneSeq[MAX_PHONE_SEQ_LEN];
-    char addWordSeq[MAX_PHONE_SEQ_LEN * MAX_UTF8_SIZE + 1];
-    int phraseState;
-    int cursor;
 
     if (!ctx) {
         return -1;
@@ -1678,11 +1672,10 @@ CHEWING_API int chewing_handle_CtrlNum(ChewingContext *ctx, int key)
 
     CheckAndResetRange(pgdata);
 
-    if (pgdata->bSelect)
+    if (pgdata->bSelect || BopomofoIsEntering(&(pgdata->bopomofoData))) {
+        MakeOutputWithRtn(pgo, pgdata, keystrokeRtn);
         return 0;
-
-    CallPhrasing(pgdata, 0);
-    newPhraseLen = key - '0';
+    }
 
     if (key == '0' || key == '1') {
         pgdata->bSelect = 1;
@@ -1694,15 +1687,24 @@ CHEWING_API int chewing_handle_CtrlNum(ChewingContext *ctx, int key)
         return 0;
     }
 
-    cursor = PhoneSeqCursor(pgdata);
-    if (!pgdata->config.bAddPhraseForward) {
-        if (newPhraseLen >= 1 && cursor + newPhraseLen - 1 <= pgdata->nPhoneSeq) {
-            if (NoSymbolBetween(pgdata, cursor, cursor + newPhraseLen)) {
+    if (key >= '2' && key <= '9') {
+        int i;
+        int newPhraseLen = key - '0';
+        int phraseState = 0;
+        int cursor = PhoneSeqCursor(pgdata);
+        int key_buf_cursor = pgdata->chiSymbolCursor;
+        uint16_t addPhoneSeq[MAX_PHONE_SEQ_LEN];
+        char addWordSeq[MAX_PHONE_SEQ_LEN * MAX_UTF8_SIZE + 1];
+
+        if (!pgdata->config.bAddPhraseForward) {
+            if (cursor + newPhraseLen <= pgdata->nPhoneSeq &&
+                NoSymbolBetween(pgdata, key_buf_cursor, key_buf_cursor + newPhraseLen)) {
+
                 /* Manually add phrase to the user phrase database. */
                 memcpy(addPhoneSeq, &pgdata->phoneSeq[cursor], sizeof(uint16_t) * newPhraseLen);
                 addPhoneSeq[newPhraseLen] = 0;
 
-                copyStringFromPreeditBuf(pgdata, cursor, newPhraseLen, addWordSeq, sizeof(addWordSeq));
+                copyStringFromPreeditBuf(pgdata, key_buf_cursor, newPhraseLen, addWordSeq, sizeof(addWordSeq));
 
                 phraseState = UserUpdatePhrase(pgdata, addPhoneSeq, addWordSeq);
                 SetUpdatePhraseMsg(pgdata, addWordSeq, newPhraseLen, phraseState);
@@ -1711,15 +1713,15 @@ CHEWING_API int chewing_handle_CtrlNum(ChewingContext *ctx, int key)
                 for (i = 1; i < newPhraseLen; i++)
                     pgdata->bUserArrBrkpt[cursor + i] = 0;
             }
-        }
-    } else {
-        if (newPhraseLen >= 1 && cursor - newPhraseLen >= 0) {
-            if (NoSymbolBetween(pgdata, cursor - newPhraseLen, cursor)) {
+        } else {
+            if (cursor - newPhraseLen >= 0 &&
+                NoSymbolBetween(pgdata, key_buf_cursor - newPhraseLen, key_buf_cursor)) {
+
                 /* Manually add phrase to the user phrase database. */
                 memcpy(addPhoneSeq, &pgdata->phoneSeq[cursor - newPhraseLen], sizeof(uint16_t) * newPhraseLen);
                 addPhoneSeq[newPhraseLen] = 0;
 
-                copyStringFromPreeditBuf(pgdata, cursor - newPhraseLen, newPhraseLen, addWordSeq, sizeof(addWordSeq));
+                copyStringFromPreeditBuf(pgdata, key_buf_cursor - newPhraseLen, newPhraseLen, addWordSeq, sizeof(addWordSeq));
 
                 phraseState = UserUpdatePhrase(pgdata, addPhoneSeq, addWordSeq);
                 SetUpdatePhraseMsg(pgdata, addWordSeq, newPhraseLen, phraseState);
@@ -1729,11 +1731,22 @@ CHEWING_API int chewing_handle_CtrlNum(ChewingContext *ctx, int key)
                     pgdata->bUserArrBrkpt[cursor - newPhraseLen + i] = 0;
             }
         }
+
+        if (!phraseState) {
+            snprintf(pgdata->showMsg, sizeof(pgdata->showMsg),
+                "\xE5\x8A\xA0\xE8\xA9\x9E\xE5\xA4\xB1\xE6\x95\x97\xEF\xBC\x9A\xE5\xAD\x97\xE6\x95\xB8"
+                "\xE4\xB8\x8D\xE7\xAC\xA6\xE6\x88\x96\xE5\xA4\xBE\xE9\x9B\x9C\xE7\xAC\xA6\xE8\x99\x9F"
+                /* 加詞失敗：字數不符或夾雜符號 */);
+            pgdata->showMsgLen = 14;
+        }
+
+        CallPhrasing(pgdata, 0);
+        MakeOutputWithRtn(pgo, pgdata, keystrokeRtn);
+        MakeOutputAddMsgAndCleanInterval(pgo, pgdata);
+        return 0;
     }
-    CallPhrasing(pgdata, 0);
-    MakeOutputWithRtn(pgo, pgdata, keystrokeRtn);
-    MakeOutputAddMsgAndCleanInterval(pgo, pgdata);
-    return 0;
+
+    return -1;
 }
 
 CHEWING_API int chewing_handle_ShiftSpace(ChewingContext *ctx)

--- a/test/test-userphrase.c
+++ b/test/test-userphrase.c
@@ -114,6 +114,11 @@ void test_CtrlNum_add_phrase_right()
     static const char msg[] = "\xE5\x8A\xA0\xE5\x85\xA5\xEF\xBC\x9A\xE6\xB8\xAC\xE8\xA9\xA6" /* 加入：測試 */ ;
     static const char msg_already_have[] =
         "\xE5\xB7\xB2\xE6\x9C\x89\xEF\xBC\x9A\xE6\xB8\xAC\xE8\xA9\xA6" /* 已有：測試 */ ;
+    static const char msg_error[] =
+        "\xE5\x8A\xA0\xE8\xA9\x9E\xE5\xA4\xB1\xE6\x95\x97\xEF\xBC\x9A\xE5\xAD\x97\xE6\x95\xB8"
+        "\xE4\xB8\x8D\xE7\xAC\xA6\xE6\x88\x96\xE5\xA4\xBE\xE9\x9B\x9C\xE7\xAC\xA6\xE8\x99\x9F"
+        /* 加詞失敗：字數不符或夾雜符號 */;
+
     int cursor;
     ChewingContext *ctx;
 
@@ -136,6 +141,9 @@ void test_CtrlNum_add_phrase_right()
     type_keystroke_by_string(ctx, "<C2>");
     ok_aux_buffer(ctx, msg_already_have);
 
+    type_keystroke_by_string(ctx, "<EN><C2>");
+    ok_aux_buffer(ctx, msg_error);
+
     chewing_delete(ctx);
 }
 
@@ -146,6 +154,11 @@ void test_CtrlNum_add_phrase_left()
     static const char msg_add[] = "\xE5\x8A\xA0\xE5\x85\xA5\xEF\xBC\x9A\xE6\xB8\xAC\xE8\xA9\xA6" /* 加入：測試 */ ;
     static const char msg_already_have[] =
         "\xE5\xB7\xB2\xE6\x9C\x89\xEF\xBC\x9A\xE6\xB8\xAC\xE8\xA9\xA6" /* 已有：測試 */ ;
+    static const char msg_error[] =
+        "\xE5\x8A\xA0\xE8\xA9\x9E\xE5\xA4\xB1\xE6\x95\x97\xEF\xBC\x9A\xE5\xAD\x97\xE6\x95\xB8"
+        "\xE4\xB8\x8D\xE7\xAC\xA6\xE6\x88\x96\xE5\xA4\xBE\xE9\x9B\x9C\xE7\xAC\xA6\xE8\x99\x9F"
+        /* 加詞失敗：字數不符或夾雜符號 */;
+
     int cursor;
     ChewingContext *ctx;
 
@@ -167,6 +180,9 @@ void test_CtrlNum_add_phrase_left()
 
     type_keystroke_by_string(ctx, "<C2>");
     ok_aux_buffer(ctx, msg_already_have);
+
+    type_keystroke_by_string(ctx, "<H><C2>");
+    ok_aux_buffer(ctx, msg_error);
 
     chewing_delete(ctx);
 }
@@ -219,12 +235,71 @@ void test_CtrlNum_add_phrase_left_symbol_in_between()
     chewing_delete(ctx);
 }
 
+void test_CtrlNum_add_phrase_right_start_with_symbol()
+{
+    static const char bopomofo[] =
+        "\xE3\x84\x89\xE3\x84\xA4\xCB\x87 \xE3\x84\x8A\xE3\x84\xA8\xCB\x87 \xE3\x84\x91\xE3\x84\xA7\xE3\x84\xA4\xCB\x8A" /* ㄉㄤˇ ㄊㄨˇ ㄑㄧㄤˊ */ ;
+    static const char phrase[] = "\xE6\x93\x8B\xE5\x9C\x9F\xE7\x89\x86"; /* 擋土牆 */
+
+    const char *const_buf;
+    ChewingContext *ctx;
+
+    clean_userphrase();
+    ctx = chewing_new();
+    start_testcase(ctx, fd);
+    chewing_set_maxChiSymbolLen(ctx, 16);
+    chewing_set_addPhraseDirection(ctx, 0);
+
+    ok(has_userphrase(ctx, bopomofo, NULL) == 0, "`%s' shall not be in userphrase", bopomofo);
+
+    type_keystroke_by_string(ctx, "`1hk4g42;3wj3fu;6<L><L><L><D>3<C3>");
+    ok(has_userphrase(ctx, bopomofo, NULL) == 1, "`%s' shall be in userphrase", bopomofo);
+
+    chewing_cand_open(ctx);
+    chewing_cand_Enumerate(ctx);
+    const_buf = chewing_cand_string_by_index_static(ctx, 0);
+    ok(strcmp(const_buf, phrase) == 0, "first candidate `%s' shall be `%s'", const_buf, phrase);
+
+    chewing_delete(ctx);
+} 
+
+void test_CtrlNum_add_phrase_left_start_with_symbol()
+{
+    static const char bopomofo[] =
+        "\xE3\x84\x89\xE3\x84\xA4\xCB\x87 \xE3\x84\x8A\xE3\x84\xA8\xCB\x87 \xE3\x84\x91\xE3\x84\xA7\xE3\x84\xA4\xCB\x8A" /* ㄉㄤˇ ㄊㄨˇ ㄑㄧㄤˊ */ ;
+    static const char phrase[] = "\xE6\x93\x8B\xE5\x9C\x9F\xE7\x89\x86"; /* 擋土牆 */
+
+    const char *const_buf;
+    ChewingContext *ctx;
+
+    clean_userphrase();
+    ctx = chewing_new();
+    start_testcase(ctx, fd);
+    chewing_set_maxChiSymbolLen(ctx, 16);
+    chewing_set_addPhraseDirection(ctx, 1);
+
+    ok(has_userphrase(ctx, bopomofo, NULL) == 0, "`%s' shall not be in userphrase", bopomofo);
+
+    type_keystroke_by_string(ctx, "`1hk4g42;3wj3fu;6<L><L><L><D>3<EN><C3>");
+    ok(has_userphrase(ctx, bopomofo, NULL) == 1, "`%s' shall be in userphrase", bopomofo);
+
+    type_keystroke_by_string(ctx, "<L><L><L>");
+    chewing_cand_open(ctx);
+    chewing_cand_Enumerate(ctx);
+    const_buf = chewing_cand_string_by_index_static(ctx, 0);
+    ok(strcmp(const_buf, phrase) == 0, "first candidate `%s' shall be `%s'", const_buf, phrase);
+
+    chewing_delete(ctx);
+}
+
 void test_CtrlNum()
 {
     test_CtrlNum_add_phrase_right();
     test_CtrlNum_add_phrase_left();
     test_CtrlNum_add_phrase_right_symbol_in_between();
     test_CtrlNum_add_phrase_left_symbol_in_between();
+    test_CtrlNum_add_phrase_right_start_with_symbol();
+    test_CtrlNum_add_phrase_left_start_with_symbol();
 }
 
 void test_userphrase_auto_learn()


### PR DESCRIPTION
1. NoSymbolBetween() and copyStringFromPreeditBuf() don't skip any
non-chinese characters, they require the cursor of pre-edit buffer.
So replace the PhoneSeqCursor with chiSymbolCursor.

2. When users press ctrl + 2-9 but there is nothing to be added
(for example, the pre-edit buffer is empty, or there are some
symbols in between), libchewing will display the old aux message,
or just nothing. However this is not desirable, it's better to
display an error message instead.

3. This function expects keys from 0 to 9. If not,
return -1 at the end.

4. add or update test cases.