### PR TITLE
Fix Travis-CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ matrix:
     - compiler: gcc
       env: BUILD=cmake
     - compiler: clang
+      # LSan does not work in containers https://github.com/travis-ci/travis-ci/issues/9033
+      sudo: true
       env: BUILD=cmake CMAKE_OPTION="-DUSE_VALGRIND=no -DNO_UNDEFINED=no" CFLAGS="-fsanitize=address -fsanitize=undefined"
     - compiler: gcc
       env: BUILD=cmake CMAKE_OPTION="-DENABLE_GCOV=yes -DUSE_VALGRIND=no" COVERALLS=yes

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_install:
   - P_JOBS="-j$(getconf _NPROCESSORS_ONLN)"
 
 script:
-  - if [ x$BUILD == xautotools ]; then ./autogen.sh && ./configure $CONFIGURE_OPTION && make $P_JOBS CFLAGS="$CFLAGS -Wall -Werror -Wno-unused-const-variable" && make $P_JOBS check && make $P_JOBS release && LC_ALL=c sort data/tsi.src > data/tsi.src.sort && diff data/tsi.src data/tsi.src.sort; fi
+  - if [ x$BUILD == xautotools ]; then ./autogen.sh && ./configure $CONFIGURE_OPTION && make $P_JOBS V=1 CFLAGS="$CFLAGS -Wall -Werror -Wno-unused-const-variable" && make $P_JOBS check && make $P_JOBS release && LC_ALL=c sort data/tsi.src > data/tsi.src.sort && diff data/tsi.src data/tsi.src.sort; fi
   - if [ x$BUILD == xcmake ]; then CFLAGS="$CFLAGS -Wall -Werror -Wno-unused-const-variable" cmake . $CMAKE_OPTION && make $P_JOBS && make $P_JOBS check && LC_ALL=C sort data/tsi.src > data/tsi.src.sort && diff data/tsi.src data/tsi.src.sort; fi
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: c
 
+dist: xenial
+
 # container-based builds
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,8 @@ before_install:
   - P_JOBS="-j$(getconf _NPROCESSORS_ONLN)"
 
 script:
-  - if [ x$BUILD == xautotools ]; then ./autogen.sh && ./configure $CONFIGURE_OPTION && make $P_JOBS CFLAGS="$CFLAGS -Wall -Werror" && make $P_JOBS check && make $P_JOBS release && LC_ALL=c sort data/tsi.src > data/tsi.src.sort && diff data/tsi.src data/tsi.src.sort; fi
-  - if [ x$BUILD == xcmake ]; then CFLAGS="$CFLAGS -Wall -Werror" cmake . $CMAKE_OPTION && make $P_JOBS && make $P_JOBS check && LC_ALL=C sort data/tsi.src > data/tsi.src.sort && diff data/tsi.src data/tsi.src.sort; fi
+  - if [ x$BUILD == xautotools ]; then ./autogen.sh && ./configure $CONFIGURE_OPTION && make $P_JOBS CFLAGS="$CFLAGS -Wall -Werror -Wno-unused-const-variable" && make $P_JOBS check && make $P_JOBS release && LC_ALL=c sort data/tsi.src > data/tsi.src.sort && diff data/tsi.src data/tsi.src.sort; fi
+  - if [ x$BUILD == xcmake ]; then CFLAGS="$CFLAGS -Wall -Werror -Wno-unused-const-variable" cmake . $CMAKE_OPTION && make $P_JOBS && make $P_JOBS check && LC_ALL=C sort data/tsi.src > data/tsi.src.sort && diff data/tsi.src data/tsi.src.sort; fi
 
 after_success:
   - if [ x$COVERALLS == xyes ]; then coveralls --exclude src/tools --exclude contrib --exclude test --exclude thirdparty --exclude-pattern '.*CMake[^/]+\.c(?:pp)?' --exclude-pattern '.*/[_A-Z0-9]+\.c(?:pp)?' --exclude-pattern '[^\.]*\.h'; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,9 @@ matrix:
     - compiler: gcc
       env: BUILD=cmake CMAKE_OPTION="-DENABLE_GCOV=yes -DUSE_VALGRIND=no" COVERALLS=yes
     - compiler: clang
-      env: BUILD=cmake CMAKE_OPTION="-DWITH_STATIC_SQLITE3=yes"
+      env: BUILD=cmake CMAKE_OPTION="-DWITH_INTERNAL_SQLITE3=yes"
     - compiler: gcc
-      env: BUILD=autotools CONFIGURE_OPTION="--with-static_sqlite3=yes"
+      env: BUILD=autotools CONFIGURE_OPTION="--with-internal-sqlite3=yes"
     - compiler: gcc
       env: BUILD=cmake CMAKE_OPTION="-DWITH_SQLITE3=no"
     - compiler: clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: c
 
 # container-based builds
-sudo: required
+sudo: false
 
 git:
   depth: 1
@@ -34,10 +34,6 @@ matrix:
 before_install:
   - pip install --user cpp-coveralls
   - P_JOBS="-j$(getconf _NPROCESSORS_ONLN)"
-  - yes | sudo add-apt-repository ppa:kalakris/cmake
-  - sudo apt-get update -qq
-
-install: sudo apt-get install cmake
 
 script:
   - if [ x$BUILD == xautotools ]; then ./autogen.sh && ./configure $CONFIGURE_OPTION && make $P_JOBS CFLAGS="$CFLAGS -Wall -Werror" && make $P_JOBS check && make $P_JOBS release && LC_ALL=c sort data/tsi.src > data/tsi.src.sort && diff data/tsi.src data/tsi.src.sort; fi
@@ -57,9 +53,6 @@ addons:
     build_command: "make $P_JOBS"
     branch_pattern: coverity_scan
   apt:
-    sources:
-    # sources list: https://github.com/travis-ci/apt-source-whitelist/blob/master/ubuntu.json
-    - kalakris-cmake
     packages:
     # packages list: https://github.com/travis-ci/apt-package-whitelist/blob/master/ubuntu-precise
     - cmake

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_install:
   - P_JOBS="-j$(getconf _NPROCESSORS_ONLN)"
 
 script:
-  - if [ x$BUILD == xautotools ]; then ./autogen.sh && ./configure $CONFIGURE_OPTION && make $P_JOBS V=1 CFLAGS="$CFLAGS -Wall -Werror -Wno-unused-const-variable" && make $P_JOBS check && make $P_JOBS release && LC_ALL=c sort data/tsi.src > data/tsi.src.sort && diff data/tsi.src data/tsi.src.sort; fi
+  - if [ x$BUILD == xautotools ]; then ./autogen.sh && ./configure $CONFIGURE_OPTION && make $P_JOBS V=1 CFLAGS="$CFLAGS -Wall -Werror -Wno-unused-const-variable" && make -j1 check && make $P_JOBS release && LC_ALL=c sort data/tsi.src > data/tsi.src.sort && diff data/tsi.src data/tsi.src.sort; fi
   - if [ x$BUILD == xcmake ]; then CFLAGS="$CFLAGS -Wall -Werror -Wno-unused-const-variable" cmake . $CMAKE_OPTION && make $P_JOBS && make $P_JOBS check && LC_ALL=C sort data/tsi.src > data/tsi.src.sort && diff data/tsi.src data/tsi.src.sort; fi
 
 after_success:

--- a/configure.ac
+++ b/configure.ac
@@ -57,7 +57,7 @@ AM_SILENT_RULES([yes])
 AC_CONFIG_HEADERS([include/config.h])
 
 # Init libtool
-LT_INIT([win32-dll])
+LT_INIT([win32-dll pic-only])
 
 # libtool option to control which symbols are exported
 # right now, symbols starting with _ are not exported


### PR DESCRIPTION
Since Aug 2017, Ubuntu Trusty is the default, and the official cmake is
new enough (2.8.12.2) - drop cmake PPA stuffs.

Also actually uses container-based instances for faster builds.

[1] https://docs.travis-ci.com/user/reference/overview/