### PR TITLE
Bump .so version as the size of a public structure is changed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -285,8 +285,8 @@ endforeach()
 
 set_target_properties(${LIBS} PROPERTIES
     OUTPUT_NAME chewing
-    SOVERSION 3
-    VERSION 3.3.1
+    SOVERSION 4
+    VERSION 4.0.0
 )
 
 # install


### PR DESCRIPTION
In https://github.com/chewing/libchewing/commit/5466d3302d8d2daf0da69a1b87f5230e663dd605
the size of `struct ChewingConfigData` is increased as a new field
`bAutoLearn` is added.

This is a preparation step for the next release (#307)