### PR TITLE
build: cmake: support cross compiling with qemu

### DIFF
--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -34,15 +34,16 @@ set_target_properties(${ALL_TOOLS} PROPERTIES
 )
 
 # tools command
+file(MAKE_DIRECTORY ${DATA_BIN_DIR})
 add_custom_command(
     OUTPUT
         ${ALL_DATA}
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${DATA_BIN_DIR}
-    COMMAND ${CMAKE_COMMAND} -E chdir ${DATA_BIN_DIR} ${TOOLS_BIN_DIR}/init_database ${DATA_SRC_DIR}/phone.cin ${DATA_SRC_DIR}/tsi.src
+    COMMAND init_database ${DATA_SRC_DIR}/phone.cin ${DATA_SRC_DIR}/tsi.src
     DEPENDS
         ${ALL_TOOLS}
         ${DATA_SRC_DIR}/phone.cin
         ${DATA_SRC_DIR}/tsi.src
+    WORKING_DIRECTORY ${DATA_BIN_DIR}
 )
 
 install(FILES ${ALL_DATA} DESTINATION ${CMAKE_INSTALL_DATADIR}/libchewing)


### PR DESCRIPTION
From version 3.6, CMake supports cross compiling to other architectures
with an emulator. In order to do that, the command must be starts with
a target built by CMake.

Let move the creation of data directory to configure phase, change the
command to exactly what CMake need, and use WORKING_DIRECTORY in
add_custom_command instead of using chdir. All of those commands are
available at CMake 2.8.8 (the oldest version that is supported).