### PR TITLE
Make the ABI consistent with 0.5.1

### DIFF
--- a/capi/chewing-internal/include/chewing_internal.h
+++ b/capi/chewing-internal/include/chewing_internal.h
@@ -363,6 +363,7 @@ typedef struct ChewingData {
   struct PhrasingOutput phrOut;
   struct BopomofoData bopomofoData;
   ChewingConfigData config;
+  int bAutoLearn;
   /**
    * Current input buffer, content == 0 means Chinese code
    */

--- a/capi/chewing-internal/src/types.rs
+++ b/capi/chewing-internal/src/types.rs
@@ -178,6 +178,7 @@ pub struct ChewingData {
     pub phr_out: PhrasingOutput,
     pub bopomofo_data: BopomofoData,
     pub config: ChewingConfigData,
+    pub b_auto_learn: c_int,
     /// Current input buffer, content == 0 means Chinese code
     pub preedit_buf: [PreeditBuf; MAX_PHONE_SEQ_LEN],
     pub chi_symbol_cursor: c_int,

--- a/capi/chewing-public/include/chewing_rs.h
+++ b/capi/chewing-public/include/chewing_rs.h
@@ -116,7 +116,6 @@ typedef struct ChewingConfigData {
   int bAutoShiftCur;
   int bEasySymbolInput;
   int bPhraseChoiceRearward;
-  int bAutoLearn;
   int hsuSelKeyType;
 } ChewingConfigData;
 

--- a/capi/chewing-public/src/types.rs
+++ b/capi/chewing-public/src/types.rs
@@ -34,7 +34,6 @@ pub struct ChewingConfigData {
     pub b_auto_shift_cur: c_int,
     pub b_easy_symbol_input: c_int,
     pub b_phrase_choice_rearward: c_int,
-    pub b_auto_learn: c_int,
     pub hsu_sel_key_type: c_int,
 }
 

--- a/include/global.h
+++ b/include/global.h
@@ -97,7 +97,6 @@ typedef struct ChewingConfigData {
     int bAutoShiftCur;
     int bEasySymbolInput;
     int bPhraseChoiceRearward;
-    int bAutoLearn;
     int hsuSelKeyType;          // Deprecated.
 } ChewingConfigData;
 

--- a/include/internal/chewing-private.h
+++ b/include/internal/chewing-private.h
@@ -234,6 +234,7 @@ typedef struct ChewingData {
     PhrasingOutput phrOut;
     BopomofoData bopomofoData;
     ChewingConfigData config;
+    int bAutoLearn;
         /** @brief current input buffer, content==0 means Chinese code */
     PreeditBuf preeditBuf[MAX_PHONE_SEQ_LEN];
     int chiSymbolCursor;

--- a/src/chewingio.c
+++ b/src/chewingio.c
@@ -811,7 +811,7 @@ CHEWING_API void chewing_set_autoLearn(ChewingContext *ctx, int mode)
     LOG_API("mode = %d", mode);
 
     if (mode == AUTOLEARN_ENABLED || mode == AUTOLEARN_DISABLED)
-        ctx->data->config.bAutoLearn = mode;
+        ctx->data->bAutoLearn = mode;
 }
 
 CHEWING_API int chewing_get_autoLearn(const ChewingContext *ctx)
@@ -823,9 +823,9 @@ CHEWING_API int chewing_get_autoLearn(const ChewingContext *ctx)
     }
     pgdata = ctx->data;
 
-    LOG_API("bAutoLearn = %d", ctx->data->config.bAutoLearn);
+    LOG_API("bAutoLearn = %d", ctx->data->bAutoLearn);
 
-    return ctx->data->config.bAutoLearn;
+    return ctx->data->bAutoLearn;
 }
 
 static void CheckAndResetRange(ChewingData *pgdata)
@@ -990,7 +990,7 @@ CHEWING_API int chewing_handle_Enter(ChewingContext *ctx)
     } else {
         keystrokeRtn = KEYSTROKE_COMMIT;
         WriteChiSymbolToCommitBuf(pgdata, pgo, nCommitStr);
-        if (!pgdata->config.bAutoLearn) {
+        if (!pgdata->bAutoLearn) {
             AutoLearnPhrase(pgdata);
         }
         CleanAllBuf(pgdata);
@@ -2419,7 +2419,7 @@ CHEWING_API int chewing_commit_preedit_buf(ChewingContext *ctx)
         return -1;
 
     WriteChiSymbolToCommitBuf(pgdata, pgo, len);
-    if (!pgdata->config.bAutoLearn) {
+    if (!pgdata->bAutoLearn) {
         AutoLearnPhrase(pgdata);
     }
     CleanAllBuf(pgdata);

--- a/src/compat.c
+++ b/src/compat.c
@@ -56,7 +56,6 @@ CHEWING_API int chewing_Configure(ChewingContext *ctx, ChewingConfigData * pcd)
     chewing_set_autoShiftCur(ctx, pcd->bAutoShiftCur);
     chewing_set_easySymbolInput(ctx, pcd->bEasySymbolInput);
     chewing_set_phraseChoiceRearward(ctx, pcd->bPhraseChoiceRearward);
-    chewing_set_autoLearn(ctx, pcd->bAutoLearn);
 
     return 0;
 }

--- a/test/test-struct-size.c
+++ b/test/test-struct-size.c
@@ -19,7 +19,6 @@ typedef struct OrigianlChewingConfigData {
     int bAutoShiftCur;
     int bEasySymbolInput;
     int bPhraseChoiceRearward;
-    int bAutoLearn;
     int hsuSelKeyType;
 } OrigianlChewingConfigData;
 


### PR DESCRIPTION
Testing:
* `chewing_set_autoLearn(ctx, AUTOLEARN_DISABLED)` still works
* Either libchewing-git with or without WITH_RUST has identical ABI as libchewing 0.5.1