### PR TITLE
refactor(trie): use smaller trie nodes and guarantee aligned memory access

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,7 +99,6 @@ version = "0.5.1-alpha.2"
 dependencies = [
  "bytemuck",
  "dirs-next",
- "fnv",
  "indexmap",
  "riff",
  "rusqlite",
@@ -254,12 +253,6 @@ name = "ffi-opaque"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec54ac60a7f2ee9a97cad9946f9bf629a3bc6a7ae59e68983dc9318f5a54b81a"
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "getrandom"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,6 +43,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bytemuck"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c041d3eab048880cb0b86b256447da3f18859a163c3b8d8893f4e6368abe6393"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aca418a974d83d40a0c1f0c5cba6ff4bc28d8df099109ca459a2118d40b6322"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "cbindgen"
 version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -77,6 +97,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 name = "chewing"
 version = "0.5.1-alpha.2"
 dependencies = [
+ "bytemuck",
  "dirs-next",
  "fnv",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ include = [
 [dependencies]
 bytemuck = { version = "1.13.0", features = ["derive"] }
 dirs-next = "2.0.0"
-fnv = "1.0.0"
 indexmap = "1.9.2"
 riff = "1.0.0"
 rusqlite = "0.28.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ include = [
 ]
 
 [dependencies]
+bytemuck = { version = "1.13.0", features = ["derive"] }
 dirs-next = "2.0.0"
 fnv = "1.0.0"
 indexmap = "1.9.2"
@@ -34,3 +35,4 @@ members = ["capi/chewing-internal", "capi/chewing-public", "tools"]
 
 [profile.release]
 lto = true
+debug = true

--- a/src/conversion/chewing_conversion.rs
+++ b/src/conversion/chewing_conversion.rs
@@ -1,10 +1,10 @@
 use std::{
+    collections::HashMap,
     fmt::{Debug, Display},
     ops::Neg,
     rc::Rc,
 };
 
-use fnv::FnvHashMap;
 use tracing::trace;
 
 use crate::{
@@ -138,11 +138,7 @@ impl ChewingConversionEngine {
     /// highest_score[1] = P(0,1)
     /// ...
     /// highest_score[y-1] = P(0,y-1)
-    fn find_best_path(
-        &self,
-        len: usize,
-        mut intervals: Vec<PossibleInterval<'_>>,
-    ) -> Vec<Interval> {
+    fn find_best_path(&self, len: usize, mut intervals: Vec<PossibleInterval<'_>>) -> Vec<Interval> {
         let mut highest_score = vec![PossiblePath::default(); len + 1];
 
         // The interval shall be sorted by the increase order of end.
@@ -380,7 +376,7 @@ impl Display for PossiblePath<'_> {
     }
 }
 
-type Graph<'a> = FnvHashMap<(usize, usize), Option<Rc<Phrase<'a>>>>;
+type Graph<'a> = HashMap<(usize, usize), Option<Rc<Phrase<'a>>>>;
 
 #[cfg(test)]
 mod tests {

--- a/src/dictionary/layered.rs
+++ b/src/dictionary/layered.rs
@@ -1,6 +1,5 @@
 use std::hash::{Hash, Hasher};
 
-use fnv::FnvBuildHasher;
 use indexmap::IndexSet;
 
 use crate::zhuyin::Syllable;
@@ -96,7 +95,7 @@ impl Dictionary for LayeredDictionary {
             Some(d) => d,
             None => return Box::new(std::iter::empty()),
         };
-        let mut phrases = IndexSet::with_capacity_and_hasher(128, FnvBuildHasher::default());
+        let mut phrases = IndexSet::with_capacity(128);
         phrases.extend(base.lookup_phrase(syllables).map(LookupPhrase));
         for d in layers {
             for phrase in d.lookup_phrase(syllables) {


### PR DESCRIPTION
The original trie node layout is less optimal.