### PR TITLE
feat: add devcontainer support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -45,13 +45,6 @@ COPY --chown=${USER} --from=rust-env /usr/local/rustup /home/${USER}/.rustup
 
 RUN set -eux; \
     rustup component add \
-    \
-    # Use rust-analyzer once MSRC reaches 1.64.0
-    # Ref:
-    # + https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1640-2022-09-22
-    # + https://github.com/chewing/libchewing/pull/347#issuecomment-1412022376
-    rls rust-analysis rust-src \
-    #
     clippy \
     rustfmt \
     ;

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,25 +1,9 @@
-ARG RUST_VERSION=1.68.2
-ARG CMAKE_VERSION=3.26.3
+# MSRV: 1.61
+# Debian (sid, bookworm): 1.63.0
+# Ubuntu LTS: 1.61.0
+ARG RUST_VERSION=1.61.0
 
 FROM rust:${RUST_VERSION} AS rust-env
-
-FROM debian:11-slim as build-base
-RUN DEBIAN_FRONTEND=noninteractive \
-    set -eux; \
-    apt-get update; \
-    apt-get install -y --no-install-recommends \
-    ca-certificates \
-    curl \
-    tar \
-    ; \
-    rm -rf /var/lib/apt/lists/*
-
-FROM build-base as cmake-env
-ARG CMAKE_VERSION
-RUN set -eux; \
-    curl -LO https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-x86_64.tar.gz; \
-    tar -xzf cmake-${CMAKE_VERSION}-linux-x86_64.tar.gz; \
-    mv cmake-${CMAKE_VERSION}-linux-x86_64 /usr/local/cmake;
 
 # Final stage
 # https://github.com/devcontainers/images/tree/main/src/base-debian
@@ -37,6 +21,7 @@ RUN DEBIAN_FRONTEND=noninteractive \
     ca-certificates \
     git \
     make \
+    cmake \
     libsqlite3-dev \
     ; \
     rm -rf /var/lib/apt/lists/*
@@ -57,11 +42,14 @@ COPY --chown=${USER} --from=rust-env /usr/local/cargo /home/${USER}/.cargo
 COPY --chown=${USER} --from=rust-env /usr/local/rustup /home/${USER}/.rustup
 
 RUN set -eux; \
-    rustup component add clippy rustfmt rust-analyzer;
-
-
-# ===========
-#    Cmake
-# ===========
-COPY --chown=${USER} --from=cmake-env /usr/local/cmake /home/${USER}/usr/local/cmake
-ENV PATH=/home/${USER}/usr/local/cmake/bin:$PATH
+    rustup component add \
+    \
+    # Use rust-analyzer once MSRC reaches 1.64.0
+    # Ref:
+    # + https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1640-2022-09-22
+    # + https://github.com/chewing/libchewing/pull/347#issuecomment-1412022376
+    rls rust-analysis rust-src \
+    #
+    clippy \
+    rustfmt \
+    ;

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -35,7 +35,7 @@ ENV RUSTUP_HOME=/home/${USER}/.rustup \
     PATH=/home/${USER}/.cargo/bin:$PATH \
     RUST_VERSION=${RUST_VERSION}
 
-# Use sparse protocol once MSVC reaches 1.68.0
+# Use sparse protocol once MSRV reaches 1.68.0
 # Ref: Sparse index protocol: https://blog.rust-lang.org/inside-rust/2023/01/30/cargo-sparse-protocol.html
 #
 # ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -35,8 +35,10 @@ ENV RUSTUP_HOME=/home/${USER}/.rustup \
     PATH=/home/${USER}/.cargo/bin:$PATH \
     RUST_VERSION=${RUST_VERSION}
 
-# Sparse index protocol: https://blog.rust-lang.org/inside-rust/2023/01/30/cargo-sparse-protocol.html
-ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
+# Use sparse protocol once MSVC reaches 1.68.0
+# Ref: Sparse index protocol: https://blog.rust-lang.org/inside-rust/2023/01/30/cargo-sparse-protocol.html
+#
+# ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 
 COPY --chown=${USER} --from=rust-env /usr/local/cargo /home/${USER}/.cargo
 COPY --chown=${USER} --from=rust-env /usr/local/rustup /home/${USER}/.rustup

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,67 @@
+ARG RUST_VERSION=1.68.2
+ARG CMAKE_VERSION=3.26.3
+
+FROM rust:${RUST_VERSION} AS rust-env
+
+FROM debian:11-slim as build-base
+RUN DEBIAN_FRONTEND=noninteractive \
+    set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    tar \
+    ; \
+    rm -rf /var/lib/apt/lists/*
+
+FROM build-base as cmake-env
+ARG CMAKE_VERSION
+RUN set -eux; \
+    curl -LO https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-x86_64.tar.gz; \
+    tar -xzf cmake-${CMAKE_VERSION}-linux-x86_64.tar.gz; \
+    mv cmake-${CMAKE_VERSION}-linux-x86_64 /usr/local/cmake;
+
+# Final stage
+# https://github.com/devcontainers/images/tree/main/src/base-debian
+FROM mcr.microsoft.com/devcontainers/base:debian
+
+ARG RUST_VERSION
+ARG USER=vscode
+
+# === Basic utility
+RUN DEBIAN_FRONTEND=noninteractive \
+    set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+    build-essential \
+    ca-certificates \
+    git \
+    make \
+    libsqlite3-dev \
+    ; \
+    rm -rf /var/lib/apt/lists/*
+
+USER ${USER}
+# ===========
+#    Rust
+# ===========
+ENV RUSTUP_HOME=/home/${USER}/.rustup \
+    CARGO_HOME=/home/${USER}/.cargo \
+    PATH=/home/${USER}/.cargo/bin:$PATH \
+    RUST_VERSION=${RUST_VERSION}
+
+# Sparse index protocol: https://blog.rust-lang.org/inside-rust/2023/01/30/cargo-sparse-protocol.html
+ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
+
+COPY --chown=${USER} --from=rust-env /usr/local/cargo /home/${USER}/.cargo
+COPY --chown=${USER} --from=rust-env /usr/local/rustup /home/${USER}/.rustup
+
+RUN set -eux; \
+    rustup component add clippy rustfmt rust-analyzer;
+
+
+# ===========
+#    Cmake
+# ===========
+COPY --chown=${USER} --from=cmake-env /usr/local/cmake /home/${USER}/usr/local/cmake
+ENV PATH=/home/${USER}/usr/local/cmake/bin:$PATH

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,41 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
+{
+	"name": "libchewing-devcontainer",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"build": {
+		"dockerfile": "./Dockerfile"
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"rust-lang.rust-analyzer",
+				"tamasfe.even-better-toml", // for Cargo.toml
+				"eamodio.gitlens", // IDE Git information
+				"shardulm94.trailing-spaces", // Show trailing spaces
+				"christian-kohler.path-intellisense",
+				"ms-azuretools.vscode-docker",
+				"genieai.chatgpt-vscode",
+				"ms-vscode.cmake-tools", // Cmake
+				// "mohsen1.prettify-json", // Prettify JSON data
+				// "spikespaz.vscode-smoothtype", // smooth cursor animation
+			],
+			"settings": {
+				"files.eol": "\n",
+				"[rust]": {
+					"editor.defaultFormatter": "rust-lang.rust-analyzer"
+				}
+			}
+		}
+	}
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "uname -a",
+	// Configure tool-specific properties.
+	// "customizations": {},
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,22 +9,22 @@
 	"customizations": {
 		"vscode": {
 			"extensions": [
-				"rust-lang.rust-analyzer",
-				"tamasfe.even-better-toml", // for Cargo.toml
 				"eamodio.gitlens", // IDE Git information
 				"shardulm94.trailing-spaces", // Show trailing spaces
 				"christian-kohler.path-intellisense",
 				"ms-azuretools.vscode-docker",
-				"genieai.chatgpt-vscode",
 				"ms-vscode.cmake-tools", // Cmake
-				// "mohsen1.prettify-json", // Prettify JSON data
-				// "spikespaz.vscode-smoothtype", // smooth cursor animation
+				// Rust language support
+				"rust-lang.rust", // Use "rust-lang.rust-analyzer" once MSRV reaches 1.64
+				// Ref:
+				// + https://github.com/chewing/libchewing/pull/347#issuecomment-1412022376
+				// + https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1640-2022-09-22
+				"tamasfe.even-better-toml", // for Cargo.toml
+				// Other
+				"genieai.chatgpt-vscode"
 			],
 			"settings": {
-				"files.eol": "\n",
-				"[rust]": {
-					"editor.defaultFormatter": "rust-lang.rust-analyzer"
-				}
+				"files.eol": "\n"
 			}
 		}
 	}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,22 +9,17 @@
 	"customizations": {
 		"vscode": {
 			"extensions": [
-				"eamodio.gitlens", // IDE Git information
 				"shardulm94.trailing-spaces", // Show trailing spaces
 				"christian-kohler.path-intellisense",
 				"ms-azuretools.vscode-docker",
 				"ms-vscode.cmake-tools", // Cmake
-				// Rust language support
-				"rust-lang.rust", // Use "rust-lang.rust-analyzer" once MSRV reaches 1.64
-				// Ref:
-				// + https://github.com/chewing/libchewing/pull/347#issuecomment-1412022376
-				// + https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1640-2022-09-22
-				"tamasfe.even-better-toml", // for Cargo.toml
-				// Other
-				"genieai.chatgpt-vscode"
+				"rust-lang.rust-analyzer" // Rust language support
 			],
 			"settings": {
-				"files.eol": "\n"
+				"files.eol": "\n",
+				"[rust]": {
+					"editor.defaultFormatter": "rust-lang.rust-analyzer"
+				}
 			}
 		}
 	}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.61"
+channel = "1.61.0"


### PR DESCRIPTION
## Overview
1. add devcontainer support

### Commands tested

+ `cargo test`
+ `cargo fmt`
+ `cargo clippy`
+ `cargo check`
+ Build with rust
  + `cmake -B build -DCMAKE_BUILD_TYPE=Release -DWITH_RUST=ON`
  + `cmake --build ./build -v --config Release`
  + `cd build && ctest -C Release --output-on-failure`
+ Build without rust
  + `cmake -B build -DCMAKE_BUILD_TYPE=Release`
  + `cmake --build ./build -v --config Release`
  + `cd build && ctest -C Release --output-on-failure`
 
 
 
