### PR TITLE
fix: devcontainer image for minimum cmake requirement

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,8 +6,8 @@ ARG RUST_VERSION=1.61.0
 FROM rust:${RUST_VERSION} AS rust-env
 
 # Final stage
-# https://github.com/devcontainers/images/tree/main/src/base-debian
-FROM mcr.microsoft.com/devcontainers/base:debian
+# https://github.com/devcontainers/images/tree/main/src/base-ubuntu
+FROM mcr.microsoft.com/devcontainers/base:ubuntu
 
 ARG RUST_VERSION
 ARG USER=vscode


### PR DESCRIPTION
fix from - 722f18b12f44dcda0e9c0ef7cf2f83379a9be78f

Update our devcontainer to use Ubuntu:jammy(cmake 3.22.1) instead of Debian:bullseye(cmake 3.18.4), which resolves issues with the required cmake version (3.19).
