### PR TITLE
feat: using cargo xtask for build & testing

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+xtask = "run --package xtask --"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,40 +17,21 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        with_rust: ['WITH_RUST=ON', 'WITH_RUST=OFF']
+        with_rust: ['true', 'false']
     runs-on: ${{ matrix.os }}
+    name: ${{ matrix.os }}, with_rust=${{ matrix.with_rust }}
 
     steps:
     - uses: actions/checkout@v3
       with:
         submodules: 'true'
-
-    - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -D${{matrix.with_rust}}
-
-    - name: Show config
-      run: cmake -B ${{github.workspace}}/build -LA
 
     - name: Build
-      run: cmake --build ${{github.workspace}}/build -v --config ${{env.BUILD_TYPE}}
-
-    - name: CTest
-      working-directory: ${{github.workspace}}/build
-      run: ctest -C ${{env.BUILD_TYPE}} --output-on-failure
-
-  cargo_test:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
-
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: 'true'
+      run: cargo xtask build --build-type ${{env.BUILD_TYPE}} --with-rust ${{matrix.with_rust}} --verbose true
 
     - name: Test
-      run: cargo test
+      run: cargo xtask test --build-type ${{env.BUILD_TYPE}}
+
 
   build_with_hash:
     runs-on: ubuntu-latest
@@ -60,15 +41,8 @@ jobs:
       with:
         submodules: 'true'
 
-    - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DWITH_SQLITE3=OFF
-
-    - name: Show config
-      run: cmake -B ${{github.workspace}}/build -LA
-
     - name: Build
-      run: cmake --build ${{github.workspace}}/build -v --config ${{env.BUILD_TYPE}}
+      run: cargo xtask build --build-type ${{env.BUILD_TYPE}} --with-rust false --with-hash true --verbose true
 
-    - name: CTest
-      working-directory: ${{github.workspace}}/build
-      run: ctest -C ${{env.BUILD_TYPE}} --output-on-failure
+    - name: Test
+      run: cargo xtask test --build-type ${{env.BUILD_TYPE}} --with-rust false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
 
 [[package]]
+name = "argh"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab257697eb9496bf75526f0217b5ed64636a9cfafa78b8365c71bd283fcef93e"
+dependencies = [
+ "argh_derive",
+ "argh_shared",
+]
+
+[[package]]
+name = "argh_derive"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b382dbd3288e053331f03399e1db106c9fb0d8562ad62cb04859ae926f324fa6"
+dependencies = [
+ "argh_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "argh_shared"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cb94155d965e3d37ffbbe7cc5b82c3dd79dd33bd48e536f73d2cfb8d85506f"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -758,3 +786,27 @@ name = "windows_x86_64_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+
+[[package]]
+name = "xshell"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "962c039b3a7b16cf4e9a4248397c6585c07547412e7d6a6e035389a802dcfe90"
+dependencies = [
+ "xshell-macros",
+]
+
+[[package]]
+name = "xshell-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dbabb1cbd15a1d6d12d9ed6b35cc6777d4af87ab3ba155ea37215f20beab80c"
+
+[[package]]
+name = "xtask"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "argh",
+ "xshell",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ rusqlite = { version = "0.28.0", features = ["bundled"]}
 tempfile = "3"
 
 [workspace]
-members = ["capi/chewing-internal", "capi/chewing-public", "tools"]
+members = ["capi/chewing-internal", "capi/chewing-public", "tools", "xtask"]
 
 [profile.release]
 lto = true

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "xtask"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+
+anyhow = "1.0.0"
+argh = "0.1.10"
+xshell = "0.2.3"

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -1,0 +1,49 @@
+use argh::FromArgs;
+
+#[derive(FromArgs, PartialEq, Debug)]
+/// xtask - running project specific tasks
+pub struct Cli {
+    #[argh(subcommand)]
+    pub cmd: Cmds,
+}
+
+#[derive(FromArgs, PartialEq, Debug)]
+#[argh(subcommand)]
+pub enum Cmds {
+    Build(CmdBuild),
+    Test(CmdTest),
+}
+
+#[derive(FromArgs, PartialEq, Debug)]
+#[argh(subcommand, name = "build")]
+/// Build project
+pub struct CmdBuild {
+    /// build with rust support
+    #[argh(option, default = "true")]
+    pub with_rust: bool,
+
+    /// using hash implementation for user-dictionary, not compatible with --with-rust
+    #[argh(option, default = "false")]
+    pub with_hash: bool,
+
+    /// show more information during build
+    #[argh(option, default = "false")]
+    pub verbose: bool,
+
+    /// CMake build type (Release, Debug, RelWithDebInfo, etc.)
+    #[argh(option, default = "String::from(\"Debug\")")]
+    pub build_type: String,
+}
+
+#[derive(FromArgs, PartialEq, Debug)]
+#[argh(subcommand, name = "test")]
+/// Running tests
+pub struct CmdTest {
+    /// CMake build type (Release, Debug, RelWithDebInfo, etc.)
+    #[argh(option, default = "String::from(\"Debug\")")]
+    pub build_type: String,
+
+    /// execute cargo test
+    #[argh(option, default = "true")]
+    pub with_rust: bool,
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,104 @@
+use anyhow::{anyhow, Context, Result};
+use std::{
+    env,
+    path::{Path, PathBuf},
+};
+use xshell::{cmd, Shell};
+
+mod cli;
+
+use cli::{Cli, Cmds};
+
+struct BuildOpts {
+    with_rust: bool,
+    with_hash: bool,
+    verbose: bool,
+    build_type: String,
+}
+
+impl BuildOpts {
+    fn run(&self, sh: &Shell) -> Result<()> {
+        // Project not fully initiallized
+        if !sh.path_exists("./cmake/corrosion") {
+            cmd!(sh, "git submodule update --init --recursive")
+                .run()
+                .with_context(|| "cannot initialize cmake submodule")?
+        }
+
+        // Configure CMake
+        let with_rust: String = format!("-DWITH_RUST={}", self.with_rust);
+        let with_sqlite3: String = format!("-DWITH_SQLITE3={}", !self.with_hash);
+        let build_type: String = format!("-DCMAKE_BUILD_TYPE={}", self.build_type);
+        cmd!(
+            sh,
+            "cmake -B ./build {with_rust} {build_type} {with_sqlite3}"
+        )
+        .run()
+        .with_context(|| "cannot configure cmake")?;
+
+        // Show build config
+        if self.verbose {
+            cmd!(sh, "cmake -B ./build -LA")
+                .run()
+                .with_context(|| "cannot show build config")?;
+        }
+
+        // Build Project
+        let build_type = format!("--config={}", self.build_type);
+        let verbose = if self.verbose { Some("-v") } else { None };
+        cmd!(sh, "cmake --build ./build {build_type} {verbose...}")
+            .run()
+            .with_context(|| "build failed")?;
+
+        Ok(())
+    }
+}
+
+fn main() -> Result<()> {
+    let app: Cli = argh::from_env();
+
+    let sh = Shell::new()?;
+    sh.change_dir(project_root());
+
+    match app.cmd {
+        Cmds::Build(ref cmd) => {
+            if cmd.with_hash && cmd.with_rust {
+                return Err(anyhow!(
+                    "--with_hash and --with_rust should not be used together"
+                ));
+            }
+            BuildOpts {
+                with_rust: cmd.with_rust,
+                with_hash: cmd.with_hash,
+                verbose: cmd.verbose,
+                build_type: cmd.build_type.clone(),
+            }
+            .run(&sh)?;
+            Ok(())
+        }
+        Cmds::Test(ref cmd) => {
+            if !sh.path_exists("./build") {
+                return Err(anyhow!("build project before running tests"));
+            }
+
+            if cmd.with_rust {
+                cmd!(sh, "cargo test").run()?;
+            }
+
+            sh.change_dir("./build");
+            let build_type = cmd.build_type.clone();
+            cmd!(sh, "ctest -C {build_type} --output-on-failure").run()?;
+            Ok(())
+        }
+    }
+}
+
+fn project_root() -> PathBuf {
+    Path::new(
+        &env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| env!("CARGO_MANIFEST_DIR").to_owned()),
+    )
+    .ancestors()
+    .nth(1)
+    .unwrap()
+    .to_path_buf()
+}


### PR DESCRIPTION
Ref: #399 

This PR wraps cmake and other build systems within `cargo xtask` to simplify the build and test processes.
We only expose build options that developer would care while developing.


Notes:

1. `cargo xtask --help` will show available subcommands
2. `cargo xtask build --help` will show available build options
3. `cargo xtask test --help` will show available test options
