### PR TITLE
build: test both msrv and stable rust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ env:
 
 jobs:
   build:
+    continue-on-error: ${{ matrix.os == 'windows-latest' }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Continuous Integration
+name: CI
 
 on:
   push:
@@ -24,7 +24,7 @@ jobs:
           - with_rust: 'false'
             rust_version: 'stable'
     runs-on: ${{ matrix.os }}
-    name: ${{ matrix.os }}, with_rust=${{ matrix.with_rust }}
+    name: ${{ matrix.os }}, with_rust=${{ matrix.with_rust }}, rust_version=${{ matrix.rust_version }}
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,9 @@ jobs:
         submodules: 'true'
 
     - name: Setup rustup
-      run: rustup default ${{ matrix.rust_version }}
+      run: |
+        rustup default ${{ matrix.rust_version }}
+        rustup update
 
     - name: Configure CMake
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -D${{matrix.with_rust}}
@@ -58,7 +60,9 @@ jobs:
         submodules: 'true'
 
     - name: Setup rustup
-      run: rustup default ${{ matrix.rust_version }}
+      run: |
+        rustup default ${{ matrix.rust_version }}
+        rustup update
 
     - name: Test
       run: cargo test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,19 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         with_rust: ['WITH_RUST=ON', 'WITH_RUST=OFF']
+        rust_version: ['1.64', 'stable']
+        exclude:
+          - with_rust: 'WITH_RUST=OFF'
+            rust_version: 'stable'
     runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v3
       with:
         submodules: 'true'
+
+    - name: Setup rustup
+      run: rustup default ${{ matrix.rust_version }}
 
     - name: Configure CMake
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -D${{matrix.with_rust}}
@@ -42,12 +49,16 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+        rust_version: ['1.64', 'stable']
     runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v3
       with:
         submodules: 'true'
+
+    - name: Setup rustup
+      run: rustup default ${{ matrix.rust_version }}
 
     - name: Test
       run: cargo test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -285,6 +285,7 @@ if (BUILD_DLL OR NOT MSVC)
             target_link_options(chewing_shared PRIVATE "-Wl,-dead_strip")
         elseif (MSVC)
             target_link_options(chewing_shared PRIVATE "/DEF ${CMAKE_BINARY_DIR}/symbols.map")
+            set_target_properties(chewing_shared PROPERTIES MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
         endif()
     endif()
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ description = "The Chewing (酷音) intelligent Zhuyin input method."
 license = "LGPL-2.1-or-later"
 documentation = "https://docs.rs/chewing"
 version = "0.5.1-alpha.2"
+rust-version = "1.64"
 edition = "2021"
 
 include = [

--- a/capi/chewing-internal/include/chewing_internal.h
+++ b/capi/chewing-internal/include/chewing_internal.h
@@ -400,6 +400,7 @@ typedef struct ChewingData {
   struct ChewingConversionEngine *ce;
   struct UserphraseDbAndEstimate *ue;
   void *phraseIter;
+  void *phraseEnumIter;
 } ChewingData;
 
 typedef struct Phrase {
@@ -553,6 +554,8 @@ void UserUpdatePhraseBegin(struct ChewingData *_pgdata);
 void UserUpdatePhraseEnd(struct ChewingData *_pgdata);
 
 void *UserEnumeratePhrase(const struct UserphraseDbAndEstimate *ue);
+
+void UserEnumeratePhraseEnd(void *iter_ptr);
 
 bool UserEnumerateHasNext(void *iter_ptr, unsigned int *phrase_len_ptr, unsigned int *bopomofo_len);
 

--- a/capi/chewing-internal/src/types.rs
+++ b/capi/chewing-internal/src/types.rs
@@ -215,6 +215,7 @@ pub struct ChewingData {
     pub ce: Option<Box<ChewingConversionEngine>>,
     pub ue: Option<Box<UserphraseDbAndEstimate>>,
     pub phrase_iter: *mut c_void,
+    pub phrase_enum_iter: *mut c_void,
 }
 
 #[repr(C)]

--- a/capi/chewing-internal/src/userphrase.rs
+++ b/capi/chewing-internal/src/userphrase.rs
@@ -227,6 +227,14 @@ pub extern "C" fn UserEnumeratePhrase(ue: &UserphraseDbAndEstimate) -> *mut c_vo
 }
 
 #[no_mangle]
+pub extern "C" fn UserEnumeratePhraseEnd(iter_ptr: *mut c_void) {
+    if !iter_ptr.is_null() {
+        let iter_ptr: *mut Peekable<DictEntries> = iter_ptr.cast();
+        let _ = unsafe { Box::from_raw(iter_ptr) };
+    }
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn UserEnumerateHasNext(
     iter_ptr: *mut c_void,
     phrase_len_ptr: *mut c_uint,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "1.61.0"

--- a/src/chewingio.c
+++ b/src/chewingio.c
@@ -447,6 +447,8 @@ CHEWING_API void chewing_delete(ChewingContext *ctx)
 #ifdef WITH_RUST
             FreePhoneticEditor(ctx->data->bopomofoData.editorWithKeymap);
             UserGetPhraseEnd(ctx->data, NULL);
+            UserEnumeratePhraseEnd(ctx->data->phraseEnumIter);
+            ctx->data->phraseEnumIter = NULL;
 #endif
             TerminateUserphrase(ctx->data);
             TerminateTree(ctx->data);
@@ -1951,8 +1953,8 @@ CHEWING_API int chewing_userphrase_enumerate(ChewingContext *ctx)
     }
 
 #ifdef WITH_RUST
-    UserGetPhraseEnd(ctx->data, NULL);
-    ctx->data->phraseIter = UserEnumeratePhrase(ctx->data->ue);
+    UserEnumeratePhraseEnd(ctx->data->phraseEnumIter);
+    ctx->data->phraseEnumIter = UserEnumeratePhrase(ctx->data->ue);
 #else
 #if WITH_SQLITE3
     int ret;
@@ -1985,7 +1987,7 @@ CHEWING_API int chewing_userphrase_has_next(ChewingContext *ctx, unsigned int *p
     }
 
 #ifdef WITH_RUST
-    return UserEnumerateHasNext(ctx->data->phraseIter, phrase_len, bopomofo_len);
+    return UserEnumerateHasNext(ctx->data->phraseEnumIter, phrase_len, bopomofo_len);
 #else
 #if WITH_SQLITE3
     int ret;
@@ -2037,7 +2039,7 @@ CHEWING_API int chewing_userphrase_get(ChewingContext *ctx,
     }
 
 #ifdef WITH_RUST
-    return UserEnumerateGet(ctx->data->phraseIter, phrase_buf, phrase_len, bopomofo_buf, bopomofo_len);
+    return UserEnumerateGet(ctx->data->phraseEnumIter, phrase_buf, phrase_len, bopomofo_buf, bopomofo_len);
 #else
 #if WITH_SQLITE3
     const char *phrase;


### PR DESCRIPTION
Don't enforce local rust version with rust-toolchain.toml so that we can use latest stable for development.

Test MSRV explicitly in CI instead.