### PR TITLE
fix: pinyin keyboard detection should not depend on enum ordering

### DIFF
--- a/include/internal/bopomofo-private.h
+++ b/include/internal/bopomofo-private.h
@@ -52,6 +52,7 @@ int BopomofoKeyseq(BopomofoData *, char key_seq[10]);
 int BopomofoSyllableIndex(BopomofoData *);
 int BopomofoSyllableIndexAlt(BopomofoData *);
 int BopomofoKbType(BopomofoData *);
+int BopomofoKbIsPinyin(BopomofoData *);
 
 /* *INDENT-OFF* */
 #endif

--- a/src/bopomofo.c
+++ b/src/bopomofo.c
@@ -664,7 +664,7 @@ int BopomofoRemoveLast(BopomofoData *pBopomofo)
 {
     int i;
 
-    if (pBopomofo->kbtype >= KB_HANYU_PINYIN) {
+    if (BopomofoKbIsPinyin(pBopomofo)) {
         i = strlen(pBopomofo->pinYinData.keySeq);
         pBopomofo->pinYinData.keySeq[i - 1] = '\0';
     } else {
@@ -690,7 +690,7 @@ int BopomofoIsEntering(BopomofoData *pBopomofo)
 {
     int i;
 
-    if (pBopomofo->kbtype >= KB_HANYU_PINYIN) {
+    if (BopomofoKbIsPinyin(pBopomofo)) {
         if (pBopomofo->pinYinData.keySeq[0])
             return 1;
     } else {

--- a/src/bopomofo.c
+++ b/src/bopomofo.c
@@ -721,3 +721,15 @@ int BopomofoKbType(BopomofoData *pBopomofo)
 {
     return pBopomofo->kbtype;
 }
+
+int BopomofoKbIsPinyin(BopomofoData *pBopomofo)
+{
+	switch (BopomofoKbType(pBopomofo)) {
+		case KB_HANYU_PINYIN:
+		case KB_THL_PINYIN:
+		case KB_MPS2_PINYIN:
+			return 1;
+		default:
+			return 0;
+	}
+}

--- a/src/chewingutil.c
+++ b/src/chewingutil.c
@@ -859,7 +859,7 @@ int MakeOutput(ChewingOutput *pgo, ChewingData *pgdata)
     pgo->chiSymbolCursor = pgdata->chiSymbolCursor;
 
     /* fill bopomofoBuf */
-    if (BopomofoKbType(&pgdata->bopomofoData) >= KB_HANYU_PINYIN) {
+    if (BopomofoKbIsPinyin(&pgdata->bopomofoData)) {
         char key_seq[10];
         BopomofoKeyseq(&pgdata->bopomofoData, key_seq);
         strcpy(pgo->bopomofoBuf, key_seq);


### PR DESCRIPTION
As discuss in #412, we should fix pinyin keyboard if statement.

Add a helper function `BopomofoKbIsPinyin(BopomofoData *)` to achieve this. 