### PR TITLE
fix(capi): chewing_cand_CheckDone result was reversed in capi

### DIFF
--- a/capi/src/io.rs
+++ b/capi/src/io.rs
@@ -1513,9 +1513,9 @@ pub unsafe extern "C" fn chewing_cand_CheckDone(ctx: *const ChewingContext) -> c
     let ctx = as_ref_or_return!(ctx, ERROR);
 
     if ctx.editor.is_selecting() {
-        TRUE
-    } else {
         FALSE
+    } else {
+        TRUE
     }
 }
 

--- a/tests/testhelper.c
+++ b/tests/testhelper.c
@@ -338,7 +338,7 @@ void internal_ok_candidate(const char *file, int line, ChewingContext *ctx, cons
 
     if (cand_len != 0) {
         internal_ok(file, line, chewing_cand_TotalPage(ctx) > 0, __func__, "shall have non-zero cand pages");
-        internal_ok(file, line, chewing_cand_CheckDone(ctx) == 1, __func__, "shall have non-zero candidates");
+        internal_ok(file, line, chewing_cand_CheckDone(ctx) == 0, __func__, "shall have zero candidates");
     }
 
     chewing_cand_Enumerate(ctx);


### PR DESCRIPTION
Fixes #504 