### PR TITLE
fix(editor): Correctly ignore instead of absorb keys when the pre-edit buffer is empty

### DIFF
--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -877,6 +877,11 @@ impl State for Entering {
                     Err(_) => self.spin_bell(),
                 }
             }
+            Enter | Esc | Tab | Home | End | Left | Right | Up | Down | PageUp | PageDown
+                if shared.com.is_empty() =>
+            {
+                self.spin_ignore()
+            }
             Tab if shared.com.is_end_of_buffer() => {
                 shared.nth_conversion += 1;
                 self.spin_absorb()
@@ -907,19 +912,17 @@ impl State for Entering {
                 self.spin_absorb()
             }
             Left if ev.modifiers.shift => {
-                if shared.com.is_empty() || shared.cursor() == 0 {
+                if shared.com.is_beginning_of_buffer() {
                     return self.spin_ignore();
                 }
                 self.start_highlighting(shared.cursor() - 1)
             }
             Right if ev.modifiers.shift => {
-                if shared.com.is_empty() || shared.com.is_end_of_buffer() {
+                if shared.com.is_end_of_buffer() {
                     return self.spin_ignore();
                 }
                 self.start_highlighting(shared.cursor() + 1)
             }
-            Left if shared.com.is_beginning_of_buffer() => self.spin_ignore(),
-            Right if shared.com.is_end_of_buffer() => self.spin_ignore(),
             Left => {
                 shared.com.move_cursor_left();
                 self.spin_absorb()
@@ -1029,6 +1032,7 @@ impl State for Entering {
                 LanguageMode::English => match shared.options.character_form {
                     CharacterForm::Halfwidth => {
                         if shared.com.is_empty() {
+                            // FIXME we should ignore these keys if pre-edit is empty
                             shared.commit_buffer.clear();
                             shared.commit_buffer.push(ev.unicode);
                             self.spin_commit()

--- a/tests/test-regression.c
+++ b/tests/test-regression.c
@@ -206,8 +206,25 @@ void test_empty_prefix_in_conversion_search()
     chewing_delete(ctx);
 }
 
-void test_empty_preedit_ignore_arrow_key()
+void test_empty_preedit_ignore_certain_keys()
 {
+    static const char *const KEYS[] = {
+        "<EE>",
+        "<E>",
+        "<DC>",
+        "<B>",
+        "<T>",
+        "<TT>",
+        "<L>",
+        "<R>",
+        "<D>",
+        "<U>",
+        "<H>",
+        "<EN>",
+        "<PU>",
+        "<PD>"
+    };
+
     ChewingContext *ctx;
     int ret;
 
@@ -216,37 +233,15 @@ void test_empty_preedit_ignore_arrow_key()
     ctx = chewing_new();
     start_testcase(ctx, fd);
 
-    type_keystroke_by_string(ctx, "<L>");
-    ret = chewing_keystroke_CheckIgnore(ctx);
-    ok(ret == 1, "Left key should be ignored");
-    ret = chewing_keystroke_CheckAbsorb(ctx);
-    ok(ret == 0, "Left key should not be absorbed");
-    ret = chewing_commit_Check(ctx);
-    ok(ret == 0, "Left key should not trigger commit");
-
-    type_keystroke_by_string(ctx, "<R>");
-    ret = chewing_keystroke_CheckIgnore(ctx);
-    ok(ret == 1, "Right key should be ignored");
-    ret = chewing_keystroke_CheckAbsorb(ctx);
-    ok(ret == 0, "Right key should not be absorbed");
-    ret = chewing_commit_Check(ctx);
-    ok(ret == 0, "Right key should not trigger commit");
-
-    type_keystroke_by_string(ctx, "<D>");
-    ret = chewing_keystroke_CheckIgnore(ctx);
-    ok(ret == 1, "Down key should be ignored");
-    ret = chewing_keystroke_CheckAbsorb(ctx);
-    ok(ret == 0, "Down key should not be absorbed");
-    ret = chewing_commit_Check(ctx);
-    ok(ret == 0, "Down key should not trigger commit");
-
-    type_keystroke_by_string(ctx, "<U>");
-    ret = chewing_keystroke_CheckIgnore(ctx);
-    ok(ret == 1, "Up key should be ignored");
-    ret = chewing_keystroke_CheckAbsorb(ctx);
-    ok(ret == 0, "Up key should not be absorbed");
-    ret = chewing_commit_Check(ctx);
-    ok(ret == 0, "Up key should not trigger commit");
+    for (int i = 0; i < ARRAY_SIZE(KEYS); ++i) {
+        type_keystroke_by_string(ctx, KEYS[i]);
+        ret = chewing_keystroke_CheckIgnore(ctx);
+        ok(ret == 1, "%s key should be ignored", KEYS[i]);
+        ret = chewing_keystroke_CheckAbsorb(ctx);
+        ok(ret == 0, "%s key should not be absorbed", KEYS[i]);
+        ret = chewing_commit_Check(ctx);
+        ok(ret == 0, "%s key should not trigger commit", KEYS[i]);
+    }
 
     chewing_delete(ctx);
 }
@@ -291,7 +286,7 @@ int main(int argc, char *argv[])
     test_move_cursor_backwards();
     test_insert_symbol_between_selection();
     test_empty_prefix_in_conversion_search();
-    test_empty_preedit_ignore_arrow_key();
+    test_empty_preedit_ignore_certain_keys();
     test_crash_found_by_fuzzing_20240505_0();
 
     fclose(fd);


### PR DESCRIPTION
Fixes #527 