### PR TITLE
Introduce dependabot version updates

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
The current configuration will present a PR (monthly) to bump Action versions used in "Github Actions" script. This will help keeping the Action versions up to date.

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates