### PR TITLE
chore(build): add option to turn off tests run

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,13 +7,7 @@ set(PACKAGE_VERSION ${CMAKE_PROJECT_VERSION})
 set(LIBCHEWING_BINARY_VERSION 1.0.0)
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
-option(BUILD_TESTS "Build and run tests." ON)
-
-if(BUILD_TESTS)
-    enable_testing()
-endif()
-
-enable_testing()
+include(CTest)
 set(CTEST_PARALLEL_LEVEL 1)
 
 if(UNIX)
@@ -220,8 +214,10 @@ if(WITH_RUST)
 endif()
 
 add_subdirectory(doc)
-add_subdirectory(tests)
 add_subdirectory(data)
+if(BUILD_TESTING)
+    add_subdirectory(tests)
+endif()
 
 # library
 add_library(common OBJECT

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,12 @@ set(PACKAGE_VERSION ${CMAKE_PROJECT_VERSION})
 set(LIBCHEWING_BINARY_VERSION 1.0.0)
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
+option(BUILD_TESTS "Build and run tests." ON)
+
+if(BUILD_TESTS)
+    enable_testing()
+endif()
+
 enable_testing()
 set(CTEST_PARALLEL_LEVEL 1)
 


### PR DESCRIPTION
would be also good to not run tests for the downstream packaging (as it is already done by CI)

relates to https://github.com/Homebrew/homebrew-core/pull/172332