### PR TITLE
build: fix building without using CMake presets

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -39,7 +39,6 @@
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Debug",
                 "BUILD_INFO": true,
-                "WITH_RUST": true,
                 "WITH_SQLITE3": false
             },
             "inherits": [
@@ -75,7 +74,6 @@
             ],
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Debug",
-                "WITH_RUST": true,
                 "WITH_SQLITE3": true
             }
         },

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -1,14 +1,7 @@
-if(WITH_RUST)
-    set(ALL_DATA
-        ${DATA_BIN_DIR}/tsi.dat
-        ${DATA_BIN_DIR}/word.dat
-    )
-else()
-    set(ALL_DATA
-        ${DATA_BIN_DIR}/dictionary.dat
-        ${DATA_BIN_DIR}/index_tree.dat
-    )
-endif()
+set(ALL_DATA
+    ${DATA_BIN_DIR}/tsi.dat
+    ${DATA_BIN_DIR}/word.dat
+)
 
 add_custom_target(data ALL DEPENDS ${ALL_DATA})
 
@@ -28,63 +21,34 @@ add_custom_target(all_static_data
 # tools
 set(ALL_TOOLS init_database)
 
-if(NOT WITH_RUST)
-    list(APPEND ALL_TOOLS dump_database)
-    add_executable(init_database ${TOOLS_SRC_DIR}/init_database.c $<TARGET_OBJECTS:common>)
-    add_executable(dump_database
-        ${TOOLS_SRC_DIR}/dump_database.c
-        $<TARGET_OBJECTS:common>
-    )
-    set_target_properties(${ALL_TOOLS} PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY ${TOOLS_BIN_DIR}
-            RUNTIME_OUTPUT_DIRECTORY_DEBUG ${TOOLS_BIN_DIR}
-            RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL ${TOOLS_BIN_DIR}
-            RUNTIME_OUTPUT_DIRECTORY_RELEASE ${TOOLS_BIN_DIR}
-            RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO ${TOOLS_BIN_DIR}
-    )
-endif()
-
 # tools command
 file(MAKE_DIRECTORY ${DATA_BIN_DIR})
-if(WITH_RUST)
-    set(DATA_COPYRIGHT "Copyright \\(c\\) 2022 libchewing Core Team")
-    set(DATA_LICENSE "LGPL-2.1-or-later")
-    set(DATA_VERSION ${LIBCHEWING_VERSION})
-    add_custom_command(
-        OUTPUT
-            ${ALL_DATA}
-        COMMAND chewing-cli init-database
-            -c ${DATA_COPYRIGHT}
-            -l ${DATA_LICENSE}
-            -r ${DATA_VERSION}
-            -t trie
-            -n 內建詞庫
-            ${DATA_SRC_DIR}/tsi.src tsi.dat
-        COMMAND chewing-cli init-database
-            -c ${DATA_COPYRIGHT}
-            -l ${DATA_LICENSE}
-            -r ${DATA_VERSION}
-            -t trie
-            -n 內建字庫
-            ${DATA_SRC_DIR}/word.src word.dat
-        DEPENDS
-            chewing-cli
-            ${DATA_SRC_DIR}/word.src
-            ${DATA_SRC_DIR}/tsi.src
-        WORKING_DIRECTORY ${DATA_BIN_DIR}
-    )
-else()
-    add_custom_command(
-        OUTPUT
-            ${ALL_DATA}
-        COMMAND init_database ${DATA_SRC_DIR}/phone.cin ${DATA_SRC_DIR}/tsi.src
-        DEPENDS
-            ${ALL_TOOLS}
-            ${DATA_SRC_DIR}/phone.cin
-            ${DATA_SRC_DIR}/tsi.src
-        WORKING_DIRECTORY ${DATA_BIN_DIR}
-    )
-endif()
+set(DATA_COPYRIGHT "Copyright \\(c\\) 2022 libchewing Core Team")
+set(DATA_LICENSE "LGPL-2.1-or-later")
+set(DATA_VERSION ${LIBCHEWING_VERSION})
+add_custom_command(
+    OUTPUT
+        ${ALL_DATA}
+    COMMAND chewing-cli init-database
+        -c ${DATA_COPYRIGHT}
+        -l ${DATA_LICENSE}
+        -r ${DATA_VERSION}
+        -t trie
+        -n 內建詞庫
+        ${DATA_SRC_DIR}/tsi.src tsi.dat
+    COMMAND chewing-cli init-database
+        -c ${DATA_COPYRIGHT}
+        -l ${DATA_LICENSE}
+        -r ${DATA_VERSION}
+        -t trie
+        -n 內建字庫
+        ${DATA_SRC_DIR}/word.src word.dat
+    DEPENDS
+        chewing-cli
+        ${DATA_SRC_DIR}/word.src
+        ${DATA_SRC_DIR}/tsi.src
+    WORKING_DIRECTORY ${DATA_BIN_DIR}
+)
 
 install(FILES ${ALL_DATA} DESTINATION ${CMAKE_INSTALL_DATADIR}/libchewing)
 install(FILES ${ALL_STATIC_DATA} DESTINATION ${CMAKE_INSTALL_DATADIR}/libchewing)


### PR DESCRIPTION
In such cases, WITH_RUST is not defined, and thus wrong CMake commands in data/CMakeLists.txt are used.

This is a follow-up of https://github.com/chewing/libchewing/pull/567, where the CMake option WITH_RUST is gone.