### PR TITLE
build: Fix installation of static data when not building tests

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,8 +2,9 @@ What's New in libchewing 0.8.4 (May 27, 2024)
 ---------------------------------------------------------
 
 * Bug fixed
-  - Config options were incorrectly reset after certain operations (introduced
+  - Config options were incorrectly reset after certain operations. (introduced
   in v0.8.0)
+  - Installation failure if build with testing off. (introduced in v0.8.3)
 
 
 What's New in libchewing 0.8.3 (May 25, 2024)

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -14,9 +14,9 @@ add_custom_target(data ALL DEPENDS ${ALL_DATA})
 
 # We need to copy static data to binary tree when using out of tree build.
 set(ALL_STATIC_DATA
-    ${DATA_BIN_DIR}/pinyin.tab
-    ${DATA_BIN_DIR}/swkb.dat
-    ${DATA_BIN_DIR}/symbols.dat
+    ${DATA_SRC_DIR}/pinyin.tab
+    ${DATA_SRC_DIR}/swkb.dat
+    ${DATA_SRC_DIR}/symbols.dat
 )
 
 add_custom_target(all_static_data


### PR DESCRIPTION
Fixes #573 