### PR TITLE
fix(editor): printable non A-Z chars should output symbols in pinyin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,7 @@ if(WITH_RUST)
         FetchContent_Declare(
             Corrosion
             GIT_REPOSITORY https://github.com/corrosion-rs/corrosion.git
-            GIT_TAG be76480232216a64f65e3b1d9794d68cbac6c690 # v0.4.5
+            GIT_TAG 64289b1d79d6d19cd2e241db515381a086bb8407 # v0.5
             FIND_PACKAGE_ARGS
         )
         FetchContent_MakeAvailable(Corrosion)

--- a/src/editor/keyboard/mod.rs
+++ b/src/editor/keyboard/mod.rs
@@ -230,6 +230,10 @@ impl KeyCode {
             _ => None,
         }
     }
+    #[rustfmt::skip]
+    pub const fn is_atoz(&self) -> bool {
+        matches!(self, A|B|C|D|E|F|G|H|I|J|K|L|M|N|O|P|Q|R|S|T|U|V|W|X|Y|Z)
+    }
 }
 
 use KeyCode::*;
@@ -246,6 +250,13 @@ pub struct KeyEvent {
     pub unicode: char,
     /// TODO: doc
     pub modifiers: Modifiers,
+}
+
+impl KeyEvent {
+    pub(crate) fn is_printable(&self) -> bool {
+        // FIXME refactor
+        self.unicode != '�'
+    }
 }
 
 impl fmt::Display for KeyEvent {

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -1027,6 +1027,32 @@ impl State for Entering {
                         shared.com.insert(Symbol::from(symbol));
                         return self.spin_absorb();
                     }
+                    if ev.is_printable() {
+                        match shared.options.character_form {
+                            CharacterForm::Halfwidth => {
+                                if shared.com.is_empty() {
+                                    // FIXME we should ignore these keys if pre-edit is empty
+                                    shared.commit_buffer.clear();
+                                    shared.commit_buffer.push(ev.unicode);
+                                    return self.spin_commit();
+                                } else {
+                                    shared.com.insert(Symbol::from(ev.unicode));
+                                    return self.spin_absorb();
+                                }
+                            }
+                            CharacterForm::Fullwidth => {
+                                let char_ = full_width_symbol_input(ev.unicode).unwrap();
+                                if shared.com.is_empty() {
+                                    shared.commit_buffer.clear();
+                                    shared.commit_buffer.push(char_);
+                                    return self.spin_commit();
+                                } else {
+                                    shared.com.insert(Symbol::from(char_));
+                                    return self.spin_absorb();
+                                }
+                            }
+                        }
+                    }
                     self.spin_bell()
                 }
                 LanguageMode::English => match shared.options.character_form {

--- a/src/editor/zhuyin_layout/pinyin.rs
+++ b/src/editor/zhuyin_layout/pinyin.rs
@@ -71,6 +71,9 @@ impl Pinyin {
 
 impl SyllableEditor for Pinyin {
     fn key_press(&mut self, key: KeyEvent) -> KeyBehavior {
+        if self.key_seq.is_empty() && !key.code.is_atoz() {
+            return KeyBehavior::KeyError;
+        }
         if ![
             KeyCode::Space,
             KeyCode::N1,

--- a/tests/test-bopomofo.c
+++ b/tests/test-bopomofo.c
@@ -2018,6 +2018,28 @@ void test_KB_HANYU()
     chewing_delete(ctx);
 }
 
+void test_KB_HANYU_direct_symbol_output()
+{
+    ChewingContext *ctx;
+
+    ctx = chewing_new();
+    start_testcase(ctx, fd);
+
+    chewing_set_KBType(ctx, KB_HANYU_PINYIN);
+
+    type_keystroke_by_string(ctx, "pin yin  123 mo2shi4");
+    ok_preedit_buffer(ctx, "拼音 123 模式");
+    chewing_clean_preedit_buf(ctx);
+
+    chewing_set_KBType(ctx, KB_HANYU_PINYIN);
+    chewing_set_ShapeMode(ctx, FULLSHAPE_MODE);
+
+    type_keystroke_by_string(ctx, "pin yin  123 mo2shi4");
+    ok_preedit_buffer(ctx, "拼音　１２３　模式");
+    chewing_clean_preedit_buf(ctx);
+
+    chewing_delete(ctx);
+}
 
 void test_KB_THL()
 {
@@ -2162,6 +2184,7 @@ void test_KB()
     test_KB_COLEMAK_DH_ORTH();
 
     test_KB_HANYU();
+    test_KB_HANYU_direct_symbol_output();
     test_KB_THL();
     test_KB_MPS2();
 }


### PR DESCRIPTION
Fixes #592 