### PR TITLE
build: force linking chewing_version obj file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,6 +193,7 @@ if(BUILD_SHARED_LIBS)
             PRIVATE LINKER:-version-script,${PROJECT_SOURCE_DIR}/capi/src/symbols-elf.map
             PRIVATE LINKER:--gc-sections
             PRIVATE LINKER:-u,chewing_new
+            PRIVATE LINKER:-u,chewing_version
         )
         set_target_properties(libchewing PROPERTIES
             LINK_DEPENDS ${PROJECT_SOURCE_DIR}/capi/src/symbols-elf.map


### PR DESCRIPTION
Fixes #602 

I didn't use theo `--whole-archive` option because it messes with linking on Windows 😞 