### PR TITLE
fix: handle special symbol input normally when easy symbol is enabled

### DIFF
--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -1045,25 +1045,16 @@ impl State for Entering {
                             }
                         }
                     }
-                    LanguageMode::Chinese if shared.options.easy_symbol_input => {
-                        // Priortize symbol input
-                        if let Some(expended) = shared.abbr.find_abbrev(ev.unicode) {
-                            expended
-                                .chars()
-                                .for_each(|ch| shared.com.insert(Symbol::from(ch)));
-                            return self.spin_absorb();
-                        }
-                        if let Some(symbol) = special_symbol_input(ev.unicode) {
-                            shared.com.insert(Symbol::from(symbol));
-                            return self.spin_absorb();
-                        }
-                        if ev.modifiers.is_none() && KeyBehavior::Absorb == shared.syl.key_press(ev)
-                        {
-                            return self.start_enter_syllable();
-                        }
-                        self.spin_bell()
-                    }
                     LanguageMode::Chinese => {
+                        if shared.options.easy_symbol_input && ev.modifiers.shift {
+                            // Priortize symbol input
+                            if let Some(expended) = shared.abbr.find_abbrev(ev.unicode) {
+                                expended
+                                    .chars()
+                                    .for_each(|ch| shared.com.insert(Symbol::from(ch)));
+                                return self.spin_absorb();
+                            }
+                        }
                         if ev.modifiers.is_none() && KeyBehavior::Absorb == shared.syl.key_press(ev)
                         {
                             return self.start_enter_syllable();

--- a/tests/test-special-symbol.c
+++ b/tests/test-special-symbol.c
@@ -46,9 +46,6 @@ static const TestData SPECIAL_SYMBOL_TABLE[] = {
     {"\\", "\xEF\xBC\xBC" /* ＼ */ },
     {"|", "\xEF\xBD\x9C" /* ｜ */ },
     {"?", "\xEF\xBC\x9F" /* ？ */ },
-    {",", "\xEF\xBC\x8C" /* ， */ },
-    {".", "\xE3\x80\x82" /* 。 */ },
-    {";", "\xEF\xBC\x9B" /* ； */ },
 };
 
 int is_bopomofo_collision_key(const char *key)


### PR DESCRIPTION
Fixes https://github.com/chewing/windows-chewing-tsf/issues/359