### PR TITLE
fix: reset state machine to Entering when switching language mode

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -13,6 +13,8 @@ What's New in libchewing (unreleased)
 * Bug Fixes
   - Auto shift cursor after candidate selection now moves the cursor to the
     next phrase instead of the next word.
+  - Fixed a bug when switching input mode from Chinese to English, the state
+    can be stuck in entering bopomofo.
 
 * Changes
   - SQLite support is now fully optional and disabled by default

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -261,7 +261,7 @@ impl Editor {
     }
     pub fn set_editor_options(&mut self, options: EditorOptions) {
         if self.shared.options.language_mode != options.language_mode {
-            self.shared.syl.clear();
+            self.cancel_entering_syllable();
         }
         self.shared.options = options;
     }
@@ -365,6 +365,11 @@ impl Editor {
         } else {
             Err(EditorError::InvalidState)
         }
+    }
+    pub fn cancel_entering_syllable(&mut self) {
+        self.shared.syl.clear();
+        self.shared.last_key_behavior = EditorKeyBehavior::Absorb;
+        self.state = Box::new(Entering);
     }
     pub fn last_key_behavior(&self) -> EditorKeyBehavior {
         self.shared.last_key_behavior

--- a/tests/test-bopomofo.c
+++ b/tests/test-bopomofo.c
@@ -330,21 +330,25 @@ void test_del_bopomofo_as_mode_switch()
     ctx = chewing_new();
     start_testcase(ctx);
 
-    type_keystroke_by_string(ctx, "2k");        /* ㄉㄜ */
+    type_keystroke_by_string(ctx, "2k72k");        /* ㄉㄜ˙ ㄉㄜ */
     ok_bopomofo_buffer(ctx, "\xe3\x84\x89\xe3\x84\x9c" /* ㄉㄜ */ );
-    ok_preedit_buffer(ctx, "");
+    ok_preedit_buffer(ctx, "的");
     chewing_set_ChiEngMode(ctx, SYMBOL_MODE);
     ok_bopomofo_buffer(ctx, "");
-    ok_preedit_buffer(ctx, "");
+    ok_preedit_buffer(ctx, "的");
+
+    // can enter English after mode switch
+    type_keystroke_by_string(ctx, "test");
+    ok_preedit_buffer(ctx, "的test");
 
     chewing_set_ChiEngMode(ctx, CHINESE_MODE);
 
     type_keystroke_by_string(ctx, "ji");        /* ㄨㄛ */
     ok_bopomofo_buffer(ctx, "\xe3\x84\xa8\xe3\x84\x9b" /* ㄨㄛ */ );
-    ok_preedit_buffer(ctx, "");
+    ok_preedit_buffer(ctx, "的test");
     chewing_set_ChiEngMode(ctx, SYMBOL_MODE);
     ok_bopomofo_buffer(ctx, "");
-    ok_preedit_buffer(ctx, "");
+    ok_preedit_buffer(ctx, "的test");
 
     chewing_delete(ctx);
 }


### PR DESCRIPTION
Fixes https://github.com/chewing/windows-chewing-tsf/issues/468
Fixes https://github.com/chewing/windows-chewing-tsf/issues/504